### PR TITLE
Adding missing pay dates

### DIFF
--- a/payroll/v_payroll.pr_employeesummary_clean.sql
+++ b/payroll/v_payroll.pr_employeesummary_clean.sql
@@ -25,7 +25,8 @@ WITH dates AS (
     ON d.pay_date BETWEEN sr.position_start_date AND DATEADD(DAY, 16, COALESCE(sr.termination_date, CONVERT(DATE,GETDATE())))  
  )
 
-SELECT sub.position_id      
+SELECT sub.associate_id
+      ,sub.position_id      
       ,sub.pay_date
       ,sub.company	
       ,sub.file_	

--- a/payroll/v_payroll.pr_employeesummary_clean.sql
+++ b/payroll/v_payroll.pr_employeesummary_clean.sql
@@ -3,72 +3,29 @@ GO
 
 CREATE OR ALTER VIEW payroll.pr_employeesummary_clean AS
 
-SELECT dates.position_id      
-      ,dates.pay_date
-      ,pay.company
-      ,pay.file_
-      ,COALESCE(pay.name,dates.last_name + ', ' + dates.first_name) AS Name
-      ,pay.home_department
-      ,pay.home_cost_number
-      ,pay.clock_
-      ,pay.total_reg_hours
-      ,pay.total_ot_hours
-      ,pay.total_hours_3_4
-      ,pay.gross_pay
-      ,pay.total_taxes
-      ,pay.total_deductions
-      ,pay.total_deposits
-      ,pay.net_pay
-      ,pay.total_reg_earnings
-      ,pay.total_reg_earnings_prev
-      ,pay.total_ot_earnings
-      ,pay.total_ot_earnings_prev
-      ,pay.total_earnings_3_4_5
-      ,pay.total_earnings_3_4_5_prev
-      ,pay.total_reg_earnings_prev - pay.total_reg_earnings AS total_reg_earnings_diff
-      ,CASE
-        WHEN (pay.total_reg_earnings_prev - pay.total_reg_earnings != 0 OR pay.total_reg_earnings IS NULL) THEN 1
-        ELSE 0
-       END AS total_reg_earnings_diff_flag
-      ,pay.total_ot_earnings_prev - pay.total_ot_earnings AS total_ot_earnings_diff
-      ,CASE
-        WHEN (pay.total_ot_earnings_prev - pay.total_ot_earnings != 0 OR pay.total_ot_earnings IS NULL)THEN 1
-        ELSE 0
-       END AS total_ot_earnings_diff_flag
-      ,pay.total_earnings_3_4_5_prev - pay.total_earnings_3_4_5 AS total_earnings_3_4_5_diff
-      ,CASE
-        WHEN (pay.total_earnings_3_4_5_prev - pay.total_earnings_3_4_5 != 0 OR pay.total_earnings_3_4_5 IS NULL) THEN 1
-        ELSE 0
-       END AS total_earnings_3_4_5_diff_flag
-       
-      ,pay.associate_id
+WITH dates AS (
+  SELECT DISTINCT pay_date
+  FROM gabby.payroll.pr_employeesummary_clean
+ )
 
+,scaffold AS (
+  SELECT sr.associate_id      
+        ,sr.preferred_first
+        ,sr.preferred_last
+        ,sr.hire_date
+        ,sr.rehire_date      
+        ,sr.position_id
+        ,sr.position_status
+        ,sr.position_start_date      
+        ,sr.termination_date
 
-FROM (
+        ,d.pay_date
+  FROM gabby.adp.staff_roster sr
+  JOIN dates d
+    ON d.pay_date BETWEEN sr.position_start_date AND DATEADD(DAY, 16, COALESCE(sr.termination_date, CONVERT(DATE,GETDATE())))  
+ )
 
-      SELECT p.associate_id
-             ,p.position_id
-             ,p.first_name
-             ,p.last_name
-             ,COALESCE(p.rehire_date, p.hire_date) AS hire_date
-             ,p.termination_date
-             ,p.position_status
-             ,e.pay_date
-
-      FROM gabby.adp.staff_roster p 
-           LEFT JOIN 
-                (SELECT DISTINCT pay_date
-                FROM gabby.payroll.pr_employeesummary_clean) e
-      ON e.pay_date BETWEEN COALESCE(p.rehire_date, p.hire_date) AND COALESCE(DATEADD(day,16,p.termination_date),DATEADD(day,16,GETDATE()))
-
-      WHERE p.termination_date IS NULL
-            OR p.termination_date >= DATEADD(day,-30,GETDATE())
-            
-           ) dates
-
-LEFT OUTER JOIN
-
-(SELECT sub.position_id      
+SELECT sub.position_id      
       ,sub.pay_date
       ,sub.company	
       ,sub.file_	
@@ -93,25 +50,30 @@ LEFT OUTER JOIN
       ,sub.total_reg_earnings_prev - sub.total_reg_earnings AS total_reg_earnings_diff
 	     ,CASE
         WHEN sub.total_reg_earnings_prev - sub.total_reg_earnings != 0 THEN 1
+        WHEN sub.total_reg_earnings IS NULL THEN 1
         ELSE 0
        END AS total_reg_earnings_diff_flag
       ,sub.total_ot_earnings_prev - sub.total_ot_earnings AS total_ot_earnings_diff
 	     ,CASE
         WHEN sub.total_ot_earnings_prev - sub.total_ot_earnings != 0 THEN 1
+        WHEN sub.total_ot_earnings IS NULL THEN 1
         ELSE 0
        END AS total_ot_earnings_diff_flag
       ,sub.total_earnings_3_4_5_prev - sub.total_earnings_3_4_5 AS total_earnings_3_4_5_diff
 	     ,CASE
         WHEN sub.total_earnings_3_4_5_prev - sub.total_earnings_3_4_5 != 0 THEN 1
+        WHEN sub.total_earnings_3_4_5 IS NULL THEN 1
         ELSE 0
-       END AS total_earnings_3_4_5_diff_flag
-       
-      ,sr.associate_id
+       END AS total_earnings_3_4_5_diff_flag       
 FROM
-
     (
-     SELECT pr.file_	
-           ,pr.name	
+     SELECT s.associate_id
+           ,s.position_id           
+           ,s.pay_date
+           ,LEFT(s.position_id, 3) AS company           
+           ,RIGHT(s.position_id, LEN(s.position_id) - 3) AS file_
+           ,CONCAT(s.preferred_last, ', ', s.preferred_first) AS name
+           
            ,pr.home_department	
            ,pr.home_cost_number	
            ,pr.clock_	
@@ -122,23 +84,16 @@ FROM
            ,pr.total_ot_earnings	
            ,pr.total_earnings_3_4_5	
            ,pr.gross_pay	
-           ,pr.total_taxes	
-           ,pr.total_deductions	
-           ,pr.total_deposits	
-           ,pr.net_pay	
-           ,pr.company	
-           ,pr.pay_date
-	          
-           ,CONCAT(pr.company, pr.file_) AS position_id
+           ,pr.total_taxes
+           ,pr.total_deductions
+           ,pr.total_deposits
+           ,pr.net_pay
+           
            ,LAG(pr.total_reg_earnings, 1, 0) OVER(PARTITION BY CONCAT(pr.company, pr.file_) ORDER BY pr.pay_date) AS total_reg_earnings_prev
            ,LAG(pr.total_ot_earnings, 1, 0) OVER(PARTITION BY CONCAT(pr.company, pr.file_) ORDER BY pr.pay_date) AS total_ot_earnings_prev
            ,LAG(pr.total_earnings_3_4_5, 1, 0) OVER(PARTITION BY CONCAT(pr.company, pr.file_) ORDER BY pr.pay_date) AS total_earnings_3_4_5_prev                      
-     FROM gabby.adp.pr_employeesummary pr
+     FROM scaffold s
+     LEFT OUTER JOIN gabby.adp.pr_employeesummary pr
+       ON s.position_id = CONCAT(pr.company, pr.file_)
+      AND s.pay_date = pr.pay_date
     ) sub
-JOIN gabby.adp.staff_roster sr
-  ON sub.position_id = sr.position_id) pay
-  
-ON dates.position_id = pay.position_id   
-   AND dates.pay_date = pay.pay_date
-
-WHERE dates.position_id IS NOT NULL

--- a/payroll/v_payroll.pr_employeesummary_clean.sql
+++ b/payroll/v_payroll.pr_employeesummary_clean.sql
@@ -3,7 +3,72 @@ GO
 
 CREATE OR ALTER VIEW payroll.pr_employeesummary_clean AS
 
-SELECT sub.position_id      
+SELECT dates.position_id      
+      ,dates.pay_date
+      ,pay.company
+      ,pay.file_
+      ,COALESCE(pay.name,dates.last_name + ', ' + dates.first_name) AS Name
+      ,pay.home_department
+      ,pay.home_cost_number
+      ,pay.clock_
+      ,pay.total_reg_hours
+      ,pay.total_ot_hours
+      ,pay.total_hours_3_4
+      ,pay.gross_pay
+      ,pay.total_taxes
+      ,pay.total_deductions
+      ,pay.total_deposits
+      ,pay.net_pay
+      ,pay.total_reg_earnings
+      ,pay.total_reg_earnings_prev
+      ,pay.total_ot_earnings
+      ,pay.total_ot_earnings_prev
+      ,pay.total_earnings_3_4_5
+      ,pay.total_earnings_3_4_5_prev
+      ,pay.total_reg_earnings_prev - pay.total_reg_earnings AS total_reg_earnings_diff
+      ,CASE
+        WHEN (pay.total_reg_earnings_prev - pay.total_reg_earnings != 0 OR pay.total_reg_earnings IS NULL) THEN 1
+        ELSE 0
+       END AS total_reg_earnings_diff_flag
+      ,pay.total_ot_earnings_prev - pay.total_ot_earnings AS total_ot_earnings_diff
+      ,CASE
+        WHEN (pay.total_ot_earnings_prev - pay.total_ot_earnings != 0 OR pay.total_ot_earnings IS NULL)THEN 1
+        ELSE 0
+       END AS total_ot_earnings_diff_flag
+      ,pay.total_earnings_3_4_5_prev - pay.total_earnings_3_4_5 AS total_earnings_3_4_5_diff
+      ,CASE
+        WHEN (pay.total_earnings_3_4_5_prev - pay.total_earnings_3_4_5 != 0 OR pay.total_earnings_3_4_5 IS NULL) THEN 1
+        ELSE 0
+       END AS total_earnings_3_4_5_diff_flag
+       
+      ,pay.associate_id
+
+
+FROM (
+
+      SELECT p.associate_id
+             ,p.position_id
+             ,p.first_name
+             ,p.last_name
+             ,COALESCE(p.rehire_date, p.hire_date) AS hire_date
+             ,p.termination_date
+             ,p.position_status
+             ,e.pay_date
+
+      FROM gabby.adp.staff_roster p 
+           LEFT JOIN 
+                (SELECT DISTINCT pay_date
+                FROM gabby.payroll.pr_employeesummary_clean) e
+      ON e.pay_date BETWEEN COALESCE(p.rehire_date, p.hire_date) AND COALESCE(DATEADD(day,16,p.termination_date),DATEADD(day,16,GETDATE()))
+
+      WHERE p.termination_date IS NULL
+            OR p.termination_date >= DATEADD(day,30,GETDATE())
+            
+           ) dates
+
+LEFT OUTER JOIN
+
+(SELECT sub.position_id      
       ,sub.pay_date
       ,sub.company	
       ,sub.file_	
@@ -43,6 +108,7 @@ SELECT sub.position_id
        
       ,sr.associate_id
 FROM
+
     (
      SELECT pr.file_	
            ,pr.name	
@@ -70,4 +136,10 @@ FROM
      FROM gabby.adp.pr_employeesummary pr
     ) sub
 JOIN gabby.adp.staff_roster sr
-  ON sub.position_id = sr.position_id
+  ON sub.position_id = sr.position_id) pay
+  
+
+ON dates.position_id = pay.position_id
+   AND dates.pay_date = pay.pay_date
+
+WHERE dates.position_id IS NOT NULL

--- a/payroll/v_payroll.pr_employeesummary_clean.sql
+++ b/payroll/v_payroll.pr_employeesummary_clean.sql
@@ -62,7 +62,7 @@ FROM (
       ON e.pay_date BETWEEN COALESCE(p.rehire_date, p.hire_date) AND COALESCE(DATEADD(day,16,p.termination_date),DATEADD(day,16,GETDATE()))
 
       WHERE p.termination_date IS NULL
-            OR p.termination_date >= DATEADD(day,30,GETDATE())
+            OR p.termination_date >= DATEADD(day,-30,GETDATE())
             
            ) dates
 
@@ -138,8 +138,7 @@ FROM
 JOIN gabby.adp.staff_roster sr
   ON sub.position_id = sr.position_id) pay
   
-
-ON dates.position_id = pay.position_id
+ON dates.position_id = pay.position_id   
    AND dates.pay_date = pay.pay_date
 
 WHERE dates.position_id IS NOT NULL

--- a/payroll/v_payroll.pr_employeesummary_clean.sql
+++ b/payroll/v_payroll.pr_employeesummary_clean.sql
@@ -5,7 +5,7 @@ CREATE OR ALTER VIEW payroll.pr_employeesummary_clean AS
 
 WITH dates AS (
   SELECT DISTINCT pay_date
-  FROM gabby.payroll.pr_employeesummary_clean
+  FROM gabby.adp.pr_employeesummary
  )
 
 ,scaffold AS (


### PR DESCRIPTION
Adds a set of all possible pay dates for everyone on the staff roster so that if someone is missing, they will still show up. It will also include folks who are terminated (for up to 30 days)

Resolves #26
