### PR TITLE
_fivetran_deleted Filter

### DIFF
--- a/payroll/v_payroll.payroll_edits_combined.sql
+++ b/payroll/v_payroll.payroll_edits_combined.sql
@@ -42,7 +42,7 @@ FROM gabby.payroll.payroll_edit_tracker e
 LEFT OUTER JOIN gabby.adp.staff_roster r
   ON e.associate_id = r.associate_id
  AND r.rn_curr = 1
- AND _fivetran_deleted IS NULL
+WHERE e._fivetran_deleted IS NULL
 
 UNION ALL
 

--- a/payroll/v_payroll.payroll_edits_combined.sql
+++ b/payroll/v_payroll.payroll_edits_combined.sql
@@ -42,6 +42,7 @@ FROM gabby.payroll.payroll_edit_tracker e
 LEFT OUTER JOIN gabby.adp.staff_roster r
   ON e.associate_id = r.associate_id
  AND r.rn_curr = 1
+ AND _fivetran_deleted IS NULL
 
 UNION ALL
 


### PR DESCRIPTION
Adding in a filter to remove all deleted rows from the payroll edits tracker. The deleted values are the result of sorting and filtering in the tracker and only "null" values should be pulled into views.