### PR TITLE
Updates to recruiting dashboards

### DIFF
--- a/recruting/v_postings_positions_clean.sql
+++ b/recruting/v_postings_positions_clean.sql
@@ -1,7 +1,7 @@
 USE gabby
 GO
 
---CREATE OR ALTER VIEW recruiting.postings_positions_clean AS
+CREATE OR ALTER VIEW recruiting.postings_positions_clean AS
 
 WITH position_setup AS (
   SELECT pn.name AS position_number           
@@ -22,32 +22,34 @@ WITH position_setup AS (
           WHEN LEN(RIGHT(pn.position_name_c, CHARINDEX('_', REVERSE(pn.position_name_c)) - 1)) > 3 THEN NULL
           ELSE LEN(RIGHT(pn.position_name_c, CHARINDEX('_', REVERSE(pn.position_name_c)) - 1))
          END AS position_count
+        
         ,pg.name AS position_job_posting
-  FROM gabby.recruiting.job_position_c pn LEFT JOIN gabby.recruiting.job_posting_c pg
+  FROM gabby.recruiting.job_position_c pn 
+  LEFT JOIN gabby.recruiting.job_posting_c pg
     ON pn.job_posting_c = pg.id
   WHERE pn.city_c IN ('Newark', 'Camden', 'Newark & Camden', 'Miami')
-  )
+ )
 
 ,positions_clean AS (
-SELECT p.position_number
-      ,p.position_name
-      ,p.city AS position_city
-      ,p.job_type AS position_type
-      ,p.sub_type AS position_sub_type
-      ,p.status AS position_status
-      ,p.new_or_replacement
-      ,p.region AS position_region
-      ,p.desired_start_date AS position_start_date
-      ,p.created_date AS position_created
-      ,p.date_filled AS position_filled
-      ,p.position_count
-      ,CASE WHEN p.n = 4 THEN PARSENAME(p.position_name_splitter,4) ELSE 'Invalid position_name Format' END AS position_recruiter
-      ,CASE WHEN p.n = 4 THEN PARSENAME(p.position_name_splitter,3) ELSE 'Invalid position_name Format' END AS position_location
-      ,CASE WHEN p.n = 4 THEN PARSENAME(p.position_name_splitter,2) ELSE 'Invalid position_name Format' END AS position_role_short
-      ,CASE WHEN p.n = 4 THEN PARSENAME(p.position_name_splitter,1) ELSE 'Invalid position_name Format' END AS position_recruiting_year
-      ,p.position_job_posting
-FROM position_setup p
-)
+  SELECT p.position_number
+        ,p.position_name
+        ,p.city AS position_city
+        ,p.job_type AS position_type
+        ,p.sub_type AS position_sub_type
+        ,p.status AS position_status
+        ,p.new_or_replacement
+        ,p.region AS position_region
+        ,p.desired_start_date AS position_start_date
+        ,p.created_date AS position_created
+        ,p.date_filled AS position_filled
+        ,p.position_count
+        ,CASE WHEN p.n = 4 THEN PARSENAME(p.position_name_splitter,4) ELSE 'Invalid position_name Format' END AS position_recruiter
+        ,CASE WHEN p.n = 4 THEN PARSENAME(p.position_name_splitter,3) ELSE 'Invalid position_name Format' END AS position_location
+        ,CASE WHEN p.n = 4 THEN PARSENAME(p.position_name_splitter,2) ELSE 'Invalid position_name Format' END AS position_role_short
+        ,CASE WHEN p.n = 4 THEN PARSENAME(p.position_name_splitter,1) ELSE 'Invalid position_name Format' END AS position_recruiting_year
+        ,p.position_job_posting
+  FROM position_setup p
+ )
 
 ,postings_clean AS (
   SELECT pg.name AS job_posting_name
@@ -65,7 +67,7 @@ FROM position_setup p
         ,pg.start_date_c AS posting_start
   FROM gabby.recruiting.job_posting_c pg
   WHERE city_c IN ('Camden', 'Newark' ,'Newark & Camden' ,'Miami')
-  )
+ )
 
 SELECT pg.job_posting_name
       ,pg.posting_created_date
@@ -97,6 +99,6 @@ SELECT pg.job_posting_name
       ,pn.position_location
       ,pn.position_role_short
       ,pn.position_recruiting_year
-
-FROM postings_clean pg LEFT JOIN positions_clean pn
-  on pg.job_posting_name = pn.position_job_posting
+FROM postings_clean pg 
+LEFT JOIN positions_clean pn
+  ON pg.job_posting_name = pn.position_job_posting

--- a/recruting/v_postings_positions_clean.sql
+++ b/recruting/v_postings_positions_clean.sql
@@ -1,0 +1,102 @@
+USE gabby
+GO
+
+--CREATE OR ALTER VIEW recruiting.postings_positions_clean AS
+
+WITH position_setup AS (
+  SELECT pn.name AS position_number           
+        ,pn.position_name_c AS position_name           
+        ,pn.city_c AS city
+        ,pn.desired_start_date_c AS desired_start_date
+        ,pn.created_date
+        ,pn.job_type_c AS job_type
+        ,pn.job_sub_type_c AS sub_type
+        ,pn.status_c AS status
+        ,pn.date_position_filled_c AS date_filled
+        ,pn.replacement_or_new_position_c AS new_or_replacement
+        ,pn.region_c AS region
+        ,LEN(pn.position_name_c) - LEN(REPLACE(pn.position_name_c, '_', '')) AS n
+        ,REPLACE(LEFT(pn.position_name_c, LEN(pn.position_name_c) - CHARINDEX('_', REVERSE(pn.position_name_c))), '_', '.') AS position_name_splitter
+        ,CASE 
+          WHEN CHARINDEX('_',pn.position_name_c) = 0 THEN NULL
+          WHEN LEN(RIGHT(pn.position_name_c, CHARINDEX('_', REVERSE(pn.position_name_c)) - 1)) > 3 THEN NULL
+          ELSE LEN(RIGHT(pn.position_name_c, CHARINDEX('_', REVERSE(pn.position_name_c)) - 1))
+         END AS position_count
+        ,pg.name AS position_job_posting
+  FROM gabby.recruiting.job_position_c pn LEFT JOIN gabby.recruiting.job_posting_c pg
+    ON pn.job_posting_c = pg.id
+  WHERE pn.city_c IN ('Newark', 'Camden', 'Newark & Camden', 'Miami')
+  )
+
+,positions_clean AS (
+SELECT p.position_number
+      ,p.position_name
+      ,p.city AS position_city
+      ,p.job_type AS position_type
+      ,p.sub_type AS position_sub_type
+      ,p.status AS position_status
+      ,p.new_or_replacement
+      ,p.region AS position_region
+      ,p.desired_start_date AS position_start_date
+      ,p.created_date AS position_created
+      ,p.date_filled AS position_filled
+      ,p.position_count
+      ,CASE WHEN p.n = 4 THEN PARSENAME(p.position_name_splitter,4) ELSE 'Invalid position_name Format' END AS position_recruiter
+      ,CASE WHEN p.n = 4 THEN PARSENAME(p.position_name_splitter,3) ELSE 'Invalid position_name Format' END AS position_location
+      ,CASE WHEN p.n = 4 THEN PARSENAME(p.position_name_splitter,2) ELSE 'Invalid position_name Format' END AS position_role_short
+      ,CASE WHEN p.n = 4 THEN PARSENAME(p.position_name_splitter,1) ELSE 'Invalid position_name Format' END AS position_recruiting_year
+      ,p.position_job_posting
+FROM position_setup p
+)
+
+,postings_clean AS (
+  SELECT pg.name AS job_posting_name
+        ,pg.created_date AS posting_created_date
+        ,pg.city_c AS posting_city
+        ,pg.subject_area_c AS posting_subject
+        ,pg.grade_c AS posting_grade
+        ,pg.grade_level_c AS posting_grade_level
+        ,pg.job_type_c AS posting_type
+        ,pg.job_sub_type_c AS posting_sub_type
+        ,pg.full_time_part_time_c AS full_or_part_time
+        ,pg.status_c AS posting_status
+        ,pg.publish_start_date_c AS posting_publish_start
+        ,pg.publish_end_date_c AS posting_publish_end
+        ,pg.start_date_c AS posting_start
+  FROM gabby.recruiting.job_posting_c pg
+  WHERE city_c IN ('Camden', 'Newark' ,'Newark & Camden' ,'Miami')
+  )
+
+SELECT pg.job_posting_name
+      ,pg.posting_created_date
+      ,pg.posting_city
+      ,pg.posting_subject
+      ,pg.posting_grade
+      ,pg.posting_grade_level
+      ,pg.posting_type
+      ,pg.posting_sub_type
+      ,pg.full_or_part_time
+      ,pg.posting_status
+      ,pg.posting_publish_start
+      ,pg.posting_publish_end
+      ,pg.posting_start
+
+      ,pn.position_number
+      ,pn.position_name
+      ,pn.position_city
+      ,pn.position_type
+      ,pn.position_sub_type
+      ,pn.new_or_replacement
+      ,pn.position_status
+      ,pn.position_region
+      ,pn.position_start_date
+      ,pn.position_created
+      ,pn.position_filled
+      ,pn.position_count
+      ,pn.position_recruiter
+      ,pn.position_location
+      ,pn.position_role_short
+      ,pn.position_recruiting_year
+
+FROM postings_clean pg LEFT JOIN positions_clean pn
+  on pg.job_posting_name = pn.position_job_posting

--- a/recruting/v_recruiting.applicants.sql
+++ b/recruting/v_recruiting.applicants.sql
@@ -1,7 +1,7 @@
 USE gabby
 GO
 
---CREATE OR ALTER VIEW recruiting.applicants AS
+CREATE OR ALTER VIEW recruiting.applicants AS
 
 WITH position_parse AS (
   SELECT pn.id
@@ -103,14 +103,14 @@ SELECT pa.id
         WHEN j.position_name_splitter IS NULL THEN NULL 
         WHEN j.n = 4 THEN PARSENAME(j.position_name_splitter, 1) 
         ELSE 'Invalid position_name Format' 
-       END AS recruiing_year
+       END AS recruiring_year
         
       ,p.name AS job_posting
 
       ,'application' as candidate_type
 
-      ,null AS cult_grade_level_interest
-      ,null AS cult_subject_interest
+      ,NULL AS cult_grade_level_interest
+      ,NULL AS cult_subject_interest
 FROM gabby.recruiting.profile_application_c pa 
 LEFT JOIN gabby.recruiting.contact c
   ON pa.contact_id_c = LEFT(c.id, 15)
@@ -121,26 +121,26 @@ LEFT JOIN position_parse  j
 LEFT JOIN gabby.recruiting.job_posting_c p
   ON j.job_posting = p.id
 
-  UNION ALL
+UNION ALL
 
 SELECT c.id AS id
       ,p.name AS profile_id
-      ,null AS years_full_time_experience
-      ,null AS years_of_full_time_teaching
-      ,null AS undergrad_school_name
-      ,null AS undergrad_major_area_of_study
-      ,null AS undergrad_gpa
-      ,null AS degree_1_school_name
-      ,null AS degree_1_major_area_of_study
-      ,null AS degree_1_gpa
-      ,null AS degree_2_school_name
-      ,null AS degree_2_major_area_of_study
-      ,null AS degree_2_gpa
-      ,null AS is_certified
-      ,null AS certificate_type
-      ,null AS certificate_subject
-      ,null AS certificate_state
-      ,null AS certificate_expiration
+      ,NULL AS years_full_time_experience
+      ,NULL AS years_of_full_time_teaching
+      ,NULL AS undergrad_school_name
+      ,NULL AS undergrad_major_area_of_study
+      ,NULL AS undergrad_gpa
+      ,NULL AS degree_1_school_name
+      ,NULL AS degree_1_major_area_of_study
+      ,NULL AS degree_1_gpa
+      ,NULL AS degree_2_school_name
+      ,NULL AS degree_2_major_area_of_study
+      ,NULL AS degree_2_gpa
+      ,NULL AS is_certified
+      ,NULL AS certificate_type
+      ,NULL AS certificate_subject
+      ,NULL AS certificate_state
+      ,NULL AS certificate_expiration
       ,co.name AS name
       ,co.email
       ,co.ethnicity_c AS race_ethnicity
@@ -148,41 +148,38 @@ SELECT c.id AS id
       ,co.title AS previous_role
       ,co.current_employer_c AS previous_employer
       ,c.name AS jobapp_id
-      ,null AS hired_status_date
-      ,null AS total_days_in_process
-      ,null AS application_review_score
-      ,null AS average_teacher_phone_score
-      ,null AS average_teacher_in_person_score
+      ,NULL AS hired_status_date
+      ,NULL AS total_days_in_process
+      ,NULL AS application_review_score
+      ,NULL AS average_teacher_phone_score
+      ,NULL AS average_teacher_in_person_score
       ,c.prospect_rating_c AS applicant_score
-      ,regional_source_c AS regional_source
-      ,COALESCE(regional_source_detail_c, referred_by_c, identified_by_c) AS regional_source_detail
-      ,first_contact_date_c AS phone_screen_or_contact_date
-      ,null AS interview_date
-      ,null AS offer_date
+      ,c.regional_source_c AS regional_source
+      ,COALESCE(c.regional_source_detail_c, c.referred_by_c, c.identified_by_c) AS regional_source_detail
+      ,c.first_contact_date_c AS phone_screen_or_contact_date
+      ,NULL AS interview_date
+      ,NULL AS offer_date
       ,c.cultivation_stage_c AS selection_stage
       ,c.current_status_c  AS selection_status
-      ,c.cultivation_notes_c 
-          + CASE WHEN c.regions_applied_to_this_year_c = null THEN null
-                 ELSE ' regions aapplied to this year: ' + c.regions_applied_to_this_year_c
-            END AS selection_notes
-      ,null AS submitted_date
-      ,null AS resume_url
-      ,null AS position_number
-      ,job_position_name_c AS position_name
-      ,null AS city
+      ,CONCAT(c.cultivation_notes_c, 'regions applied to this year: ' + c.regions_applied_to_this_year_c) AS selection_notes
+      ,NULL AS submitted_date
+      ,NULL AS resume_url
+      ,NULL AS position_number
+      ,c.job_position_name_c AS position_name
+      ,NULL AS city
       ,c.experience_type_c AS job_type
-      ,null AS sub_type
-      ,null AS status
-      ,null AS new_or_replacement
-      ,null AS region
-      ,null AS desired_start_date
+      ,NULL AS sub_type
+      ,NULL AS status
+      ,NULL AS new_or_replacement
+      ,NULL AS region
+      ,NULL AS desired_start_date
       ,c.created_date AS created_date
-      ,null AS date_filled
-      ,null AS position_count
-      ,null AS recruiter
-      ,null AS location
-      ,null AS role_short
-      ,COALESCE(future_prospect_year_c, (CONVERT(varchar,gabby.utilities.DATE_TO_SY(c.created_date)) + '-' + CONVERT(varchar,gabby.utilities.DATE_TO_SY(c.created_date)+1))) AS recruiing_year
+      ,NULL AS date_filled
+      ,NULL AS position_count
+      ,NULL AS recruiter
+      ,NULL AS location
+      ,NULL AS role_short
+      ,COALESCE(c.future_prospect_year_c, (CONVERT(VARCHAR(25),gabby.utilities.DATE_TO_SY(c.created_date)) + '-' + CONVERT(VARCHAR(25),gabby.utilities.DATE_TO_SY(c.created_date) + 1))) AS recruiting_year
       ,c.instructional_experience_level_c AS job_posting
       ,'culitvation' AS candidate_type
       ,c.primary_interest_general_grade_level_c AS cult_grade_level_interest
@@ -192,6 +189,4 @@ LEFT JOIN gabby.recruiting.profile_application_c p
   ON c.contact_c = p.applicant_c
 LEFT JOIN gabby.recruiting.contact co
   ON c.contact_c = LEFT(co.id, 15)
-
-WHERE p.name NOT IN (SELECT name FROM gabby.recruiting.profile_application_c)
-   OR p.name IS NULL
+WHERE p.name IS NULL


### PR DESCRIPTION
1 - Creating a list of postings and positions: they're linked via job posting names because postings are regularly taken down and reposted - we want to link the postion to the currently-posted jobs while still maintaining historical access. I considered using dates as part of the join, but it can be pretty complicated with recruiters adding positions after the position is filled (eg: we found a great person - let's find a role for them) or even before a posting goes up in some cases (eg: I'm thinking about hiring an X, but don't post the job yet). Happy to dig in if there's a better method. 

2 - adding cultivations to the list of applicants