### PR TITLE
Changing from SAM account to Userprincipal name

### DIFF
--- a/surveys/v_surveys.manager_survey_detail.sql
+++ b/surveys/v_surveys.manager_survey_detail.sql
@@ -61,10 +61,10 @@ FROM
            ,COALESCE(dfdf.legal_entity_name, dfadp.legal_entity_name) AS region
            ,COALESCE(dfdf.manager_adp_associate_id, dfadp.manager_adp_associate_id) AS subject_manager_id
 
-           ,COALESCE(dfdf.samaccountname, dfadp.samaccountname) AS subject_username
+           ,LOWER(COALESCE(LEFT(dfdf.userprincipalname,CHARINDEX('@',dfdf.userprincipalname)-1), dfadp.samaccountname)) AS subject_username
 
            ,COALESCE(dfdf.manager_name, dfadp.manager_name) AS subject_manager_name
-           ,COALESCE(dfdf.manager_samaccountname, dfadp.manager_samaccountname) AS subject_manager_username
+           ,LOWER(COALESCE(LEFT(dfdf.manager_userprincipalname,CHARINDEX('@',dfdf.manager_userprincipalname)-1), dfadp.manager_samaccountname)) AS subject_manager_username
      FROM gabby.surveys.manager_survey_long_static mgr     
      LEFT JOIN gabby.people.staff_crosswalk_static dfdf
        ON mgr.subject_associate_id = CONVERT(VARCHAR,dfdf.df_employee_number)

--- a/surveys/v_surveys.manager_survey_detail.sql
+++ b/surveys/v_surveys.manager_survey_detail.sql
@@ -61,10 +61,16 @@ FROM
            ,COALESCE(dfdf.legal_entity_name, dfadp.legal_entity_name) AS region
            ,COALESCE(dfdf.manager_adp_associate_id, dfadp.manager_adp_associate_id) AS subject_manager_id
 
-           ,LOWER(COALESCE(LEFT(dfdf.userprincipalname,CHARINDEX('@',dfdf.userprincipalname)-1), dfadp.samaccountname)) AS subject_username
+           ,LOWER(COALESCE(
+               LEFT(dfdf.userprincipalname, CHARINDEX('@', dfdf.userprincipalname) - 1)
+              ,dfadp.samaccountname
+             )) AS subject_username
 
            ,COALESCE(dfdf.manager_name, dfadp.manager_name) AS subject_manager_name
-           ,LOWER(COALESCE(LEFT(dfdf.manager_userprincipalname,CHARINDEX('@',dfdf.manager_userprincipalname)-1), dfadp.manager_samaccountname)) AS subject_manager_username
+           ,LOWER(COALESCE(
+               LEFT(dfdf.manager_userprincipalname, CHARINDEX('@', dfdf.manager_userprincipalname) - 1)
+              ,dfadp.manager_samaccountname
+             )) AS subject_manager_username
      FROM gabby.surveys.manager_survey_long_static mgr     
      LEFT JOIN gabby.people.staff_crosswalk_static dfdf
        ON mgr.subject_associate_id = CONVERT(VARCHAR,dfdf.df_employee_number)

--- a/surveys/v_surveys.self_and_others_survey_detail.sql
+++ b/surveys/v_surveys.self_and_others_survey_detail.sql
@@ -34,10 +34,16 @@ SELECT so.survey_type
       ,COALESCE(dfid.primary_site_school_level, adpid.primary_site_school_level) AS subject_primary_site_school_level
       ,COALESCE(dfid.manager_df_employee_number, adpid.manager_df_employee_number) AS subject_manager_id      
 
-      ,COALESCE(LEFT(dfid.userprincipalname,CHARINDEX('@',dfid.userprincipalname)-1), adpid.samaccountname) AS subject_username
+      ,COALESCE(
+          LEFT(dfid.userprincipalname, CHARINDEX('@', dfid.userprincipalname) - 1)
+         ,adpid.samaccountname
+        ) AS subject_username
 
       ,COALESCE(dfid.preferred_name, adpid.preferred_name) AS subject_manager_name
-      ,COALESCE(LEFT(dfid.manager_userprincipalname,CHARINDEX('@',dfid.manager_userprincipalname)-1), adpid.manager_samaccountname) AS subject_manager_username
+      ,COALESCE(
+          LEFT(dfid.manager_userprincipalname, CHARINDEX('@', dfid.manager_userprincipalname) - 1)
+         ,adpid.manager_samaccountname
+        ) AS subject_manager_username
 
       ,NULL AS avg_response_value_location
 FROM gabby.surveys.self_and_others_survey_long_static so

--- a/surveys/v_surveys.self_and_others_survey_detail.sql
+++ b/surveys/v_surveys.self_and_others_survey_detail.sql
@@ -34,10 +34,10 @@ SELECT so.survey_type
       ,COALESCE(dfid.primary_site_school_level, adpid.primary_site_school_level) AS subject_primary_site_school_level
       ,COALESCE(dfid.manager_df_employee_number, adpid.manager_df_employee_number) AS subject_manager_id      
 
-      ,COALESCE(dfid.samaccountname, adpid.samaccountname) AS subject_username
+      ,COALESCE(LEFT(dfid.userprincipalname,CHARINDEX('@',dfid.userprincipalname)-1), adpid.samaccountname) AS subject_username
 
       ,COALESCE(dfid.preferred_name, adpid.preferred_name) AS subject_manager_name
-      ,COALESCE(dfid.manager_samaccountname, adpid.manager_samaccountname) AS subject_manager_username
+      ,COALESCE(LEFT(dfid.manager_userprincipalname,CHARINDEX('@',dfid.manager_userprincipalname)-1), adpid.manager_samaccountname) AS subject_manager_username
 
       ,NULL AS avg_response_value_location
 FROM gabby.surveys.self_and_others_survey_long_static so

--- a/tableau/v_tableau.pm_etr_dashboard.sql
+++ b/tableau/v_tableau.pm_etr_dashboard.sql
@@ -14,8 +14,8 @@ SELECT sr.df_employee_number
       ,sr.primary_site_schoolid
       ,sr.manager_name
       ,sr.original_hire_date
-      ,LEFT(sr.userprincipalname,CHARINDEX('@',sr.userprincipalname)-1) AS staff_username
-      ,LEFT(sr.manager_userprincipalname,CHARINDEX('@',sr.manager_userprincipalname)-1) AS manager_username
+      ,LEFT(sr.userprincipalname, CHARINDEX('@', sr.userprincipalname) - 1) AS staff_username
+      ,LEFT(sr.manager_userprincipalname, CHARINDEX('@', sr.manager_userprincipalname) - 1) AS manager_username
 
       ,wo.observation_id
       ,wo.observed_at

--- a/tableau/v_tableau.pm_etr_dashboard.sql
+++ b/tableau/v_tableau.pm_etr_dashboard.sql
@@ -14,8 +14,8 @@ SELECT sr.df_employee_number
       ,sr.primary_site_schoolid
       ,sr.manager_name
       ,sr.original_hire_date
-      ,sr.samaccountname AS staff_username
-      ,sr.manager_samaccountname AS manager_username
+      ,LEFT(sr.userprincipalname,CHARINDEX('@',sr.userprincipalname)-1) AS staff_username
+      ,LEFT(sr.manager_userprincipalname,CHARINDEX('@',sr.manager_userprincipalname)-1) AS manager_username
 
       ,wo.observation_id
       ,wo.observed_at


### PR DESCRIPTION
SAM account sometimes doesn't include the second half of names eg; Diane Adams-White's samaccount is dadams, and her userprincipal name is dadams-white. Tableau uses Userprincipal name for it's active user, so it was getting thrown off.