### PR TITLE
Survey updates

### DIFF
--- a/surveys/v_surveys.cmo_engagement_regional_survey_detail.sql
+++ b/surveys/v_surveys.cmo_engagement_regional_survey_detail.sql
@@ -32,7 +32,7 @@ LEFT JOIN gabby.dayforce.work_assignment_status w
                           AND COALESCE(w.effective_end_date, DATEFROMPARTS((d.campaign_academic_year + 1), 7, 1))
 WHERE d.survey_id = 5300913
   AND d.rn_respondent_subject = 1
-  AND d.campaign_academic_year >= (gabby.utilities.GLOBAL_ACADEMIC_YEAR() - 1)
+  AND d.campaign_academic_year >= 2018
 
 UNION ALL
 

--- a/surveys/v_surveys.manager_survey_detail.sql
+++ b/surveys/v_surveys.manager_survey_detail.sql
@@ -42,7 +42,7 @@ LEFT JOIN gabby.people.staff_crosswalk_static s
   ON d.subject_df_employee_number = s.df_employee_number
 WHERE d.survey_title = 'Manager Survey'
   AND d.rn_respondent_subject = 1
-  AND d.campaign_academic_year >= (gabby.utilities.GLOBAL_ACADEMIC_YEAR() - 1)
+  AND d.campaign_academic_year >= 2018
 
 UNION ALL
 

--- a/surveys/v_surveys.self_and_others_survey_detail.sql
+++ b/surveys/v_surveys.self_and_others_survey_detail.sql
@@ -73,7 +73,7 @@ LEFT JOIN gabby.people.staff_crosswalk_static s
   ON d.subject_df_employee_number = s.df_employee_number
 WHERE d.survey_title = 'Self and Others'
   AND d.rn_respondent_subject = 1
-  AND d.campaign_academic_year >= (gabby.utilities.GLOBAL_ACADEMIC_YEAR() - 1)
+  AND d.campaign_academic_year >= 2018
 
 UNION ALL 
 


### PR DESCRIPTION
Once this is merged, we'll be able to kill the survey_gizmo webhooks because we'll be running off of the API.

I also adjusted a few views so that they will include all data since 2018 (when we started using the SG API).