### PR TITLE
Update v_surveys.survey_completion.sql

### DIFF
--- a/surveys/v_surveys.survey_completion.sql
+++ b/surveys/v_surveys.survey_completion.sql
@@ -4,61 +4,63 @@ GO
 CREATE OR ALTER VIEW surveys.survey_completion AS
 
 WITH survey_feed AS (
-  SELECT _created AS date_created
-        ,CONVERT(DATETIME2,s.survey_timestamp) AS date_submitted
+  SELECT s._created AS date_created
+        ,CONVERT(DATETIME2, s.survey_timestamp) AS date_submitted
         ,s.subject_name
         ,LOWER(s.email) AS responder_email
         ,gabby.utilities.DATE_TO_SY(s._created) AS academic_year
-        ,CASE WHEN c.name LIKE '%SO1%' THEN 'SO1'
-								      WHEN c.name LIKE '%SO2%' THEN 'SO2'
-														WHEN c.name LIKE '%SO3%' THEN 'SO3'
-														WHEN c.name LIKE '%SO4%' THEN 'SO4'
-									END AS reporting_term
+        ,CASE 
+          WHEN c.[name] LIKE '%SO1%' THEN 'SO1'
+          WHEN c.[name] LIKE '%SO2%' THEN 'SO2'
+          WHEN c.[name] LIKE '%SO3%' THEN 'SO3'
+          WHEN c.[name] LIKE '%SO4%' THEN 'SO4'
+         END AS reporting_term
         ,'Self & Others' AS survey_type
         ,s.is_manager
   FROM gabby.surveys.self_and_others_survey s
-		LEFT JOIN gabby.surveygizmo.survey_campaign_clean_static c
-		  ON c.survey_id = 4561325
-			AND CONVERT(DATETIME2,s.survey_timestamp) BETWEEN c.link_open_date AND c.link_close_date
+  LEFT JOIN gabby.surveygizmo.survey_campaign_clean_static c
+    ON c.survey_id = 4561325
+   AND CONVERT(DATETIME2, s.survey_timestamp) BETWEEN c.link_open_date AND c.link_close_date
   WHERE s.subject_name IS NOT NULL
     AND s._created IS NOT NULL
 
   UNION ALL
 
   SELECT m._created AS date_created
-        ,CONVERT(DATETIME2,m.survey_timestamp) AS date_submitted
+        ,CONVERT(DATETIME2, m.survey_timestamp) AS date_submitted
         ,m.subject_name
         ,LOWER(m.responder_name) AS responder_email
         ,gabby.utilities.DATE_TO_SY(m._created) AS academic_year
-        ,CASE WHEN c.name LIKE '%MGR1%' THEN 'MGR1'
-								      WHEN c.name LIKE '%MGR2%' THEN 'MGR2'
-														WHEN c.name LIKE '%MGR3%' THEN 'MGR3'
-														WHEN c.name LIKE '%MGR4%' THEN 'MGR4'
-									END AS reporting_term
+        ,CASE 
+          WHEN c.[name] LIKE '%MGR1%' THEN 'MGR1'
+          WHEN c.[name] LIKE '%MGR2%' THEN 'MGR2'
+          WHEN c.[name] LIKE '%MGR3%' THEN 'MGR3'
+          WHEN c.[name] LIKE '%MGR4%' THEN 'MGR4'
+         END AS reporting_term
         ,'Manager' AS survey_type
         ,NULL AS is_manager
   FROM gabby.surveys.manager_survey m
-		LEFT JOIN gabby.surveygizmo.survey_campaign_clean_static c
-		  ON c.survey_id = 4561288
-			AND CONVERT(DATETIME2,m.survey_timestamp) BETWEEN c.link_open_date AND c.link_close_date
-  WHERE subject_name IS NOT NULL
-    AND _created IS NOT NULL
-    AND subject_name IS NOT NULL
-    AND q_1 IS NOT NULL
+  LEFT JOIN gabby.surveygizmo.survey_campaign_clean_static c
+    ON c.survey_id = 4561288
+   AND CONVERT(DATETIME2, m.survey_timestamp) BETWEEN c.link_open_date AND c.link_close_date
+  WHERE m.subject_name IS NOT NULL
+    AND m._created IS NOT NULL
+    AND m.subject_name IS NOT NULL
+    AND m.q_1 IS NOT NULL
 
   UNION ALL
 
-  SELECT date_started AS date_created
-        ,CONVERT(DATETIME2,date_submitted) AS date_submitted
+  SELECT r.date_started AS date_created
+        ,CONVERT(DATETIME2, r.date_submitted) AS date_submitted
         ,'R9/Engagement' AS subject_name
-        ,LOWER(respondent_mail) AS responder_email
-        ,gabby.utilities.DATE_TO_SY(date_submitted) AS academic_year
-        ,campaign_reporting_term AS reporting_term
+        ,LOWER(r.respondent_mail) AS responder_email
+        ,gabby.utilities.DATE_TO_SY(r.date_submitted) AS academic_year
+        ,r.campaign_reporting_term AS reporting_term
         ,'R9/Engagement' AS survey
         ,NULL AS is_manager
-  FROM gabby.surveygizmo.survey_response_identifiers_static
-  WHERE survey_id = 5300913
-    AND status = 'Complete'
+  FROM gabby.surveygizmo.survey_response_identifiers_static r
+  WHERE r.survey_id = 5300913
+    AND r.[status] = 'Complete'
  )
 
 ,teacher_scaffold AS (
@@ -68,7 +70,10 @@ WITH survey_feed AS (
         ,sr.preferred_name
         ,sr.primary_site AS location_custom
         ,sr.primary_job AS job_title_description
-        ,CASE WHEN sr.status IN ('INACTIVE', 'ADMIN_LEAVE') THEN 'LEAVE' ELSE sr.status END AS position_status
+        ,CASE 
+          WHEN sr.[status] IN ('INACTIVE', 'ADMIN_LEAVE') THEN 'LEAVE' 
+          ELSE sr.[status] 
+         END AS position_status
         ,LOWER(sr.userprincipalname) as email1
         ,CASE 
           WHEN LOWER(REPLACE(sr.userprincipalname, '-', '')) = LOWER(sr.userprincipalname) THEN NULL
@@ -80,11 +85,11 @@ WITH survey_feed AS (
          END AS email3
 
         ,'Self & Others' AS survey_type
-        ,ss.value AS reporting_term
+        ,ss.[value] AS reporting_term
         ,gabby.utilities.GLOBAL_ACADEMIC_YEAR() AS academic_year
   FROM gabby.people.staff_crosswalk_static sr
   CROSS JOIN STRING_SPLIT('SO1,SO2,SO3', ',') ss
-  WHERE sr.status NOT IN ('TERMINATED', 'PRESTART')
+  WHERE sr.[status] NOT IN ('TERMINATED', 'PRESTART')
 
   UNION ALL
 
@@ -94,7 +99,10 @@ WITH survey_feed AS (
         ,sr.preferred_name
         ,sr.primary_site AS location_custom
         ,sr.primary_job AS job_title_description                  
-        ,CASE WHEN sr.status IN ('INACTIVE', 'ADMIN_LEAVE') THEN 'LEAVE' ELSE sr.status END AS position_status
+        ,CASE 
+          WHEN sr.[status] IN ('INACTIVE', 'ADMIN_LEAVE') THEN 'LEAVE' 
+          ELSE sr.[status] 
+         END AS position_status
         ,LOWER(sr.userprincipalname) as email1
         ,CASE 
           WHEN LOWER(REPLACE(sr.userprincipalname, '-', '')) = LOWER(sr.userprincipalname) THEN NULL
@@ -106,11 +114,11 @@ WITH survey_feed AS (
          END AS email3
 
         ,'R9/Engagement' AS survey_type
-        ,ss.value AS reporting_term
+        ,ss.[value] AS reporting_term
         ,gabby.utilities.GLOBAL_ACADEMIC_YEAR() AS academic_year
   FROM gabby.people.staff_crosswalk_static sr
   CROSS JOIN STRING_SPLIT('R9S1,R9S2,R9S3,R9S4', ',') ss
-  WHERE sr.status NOT IN ('TERMINATED', 'PRESTART')
+  WHERE sr.[status] NOT IN ('TERMINATED', 'PRESTART')
 
   UNION ALL
 
@@ -119,9 +127,12 @@ WITH survey_feed AS (
         ,sr.preferred_last_name AS preferred_last
         ,sr.preferred_name
         ,sr.primary_site AS location_custom
-        ,sr.primary_job AS job_title_description                  
-        ,CASE WHEN sr.status IN ('INACTIVE', 'ADMIN_LEAVE') THEN 'LEAVE' ELSE sr.status END AS position_status        
-        
+        ,sr.primary_job AS job_title_description
+        ,CASE 
+          WHEN sr.[status] IN ('INACTIVE', 'ADMIN_LEAVE') THEN 'LEAVE' 
+          ELSE sr.[status]
+         END AS position_status
+
         ,LOWER(sr.userprincipalname) as email1
         ,CASE 
           WHEN LOWER(REPLACE(sr.userprincipalname, '-', '')) = LOWER(sr.userprincipalname) THEN NULL
@@ -133,11 +144,11 @@ WITH survey_feed AS (
          END AS email3
 
         ,'Manager' AS survey_type
-        ,ss.value AS reporting_term
+        ,ss.[value] AS reporting_term
         ,gabby.utilities.GLOBAL_ACADEMIC_YEAR() AS academic_year
   FROM gabby.people.staff_crosswalk_static sr
   CROSS JOIN STRING_SPLIT('MGR1,MGR2,MGR3,MGR4', ',') ss
-  WHERE sr.status NOT IN ('TERMINATED', 'PRESTART')
+  WHERE sr.[status] NOT IN ('TERMINATED', 'PRESTART')
  )
 
 SELECT s.df_employee_number AS df_employee_number
@@ -152,10 +163,10 @@ SELECT s.df_employee_number AS df_employee_number
       ,COALESCE(f1.date_submitted, f2.date_submitted, f3.date_submitted) AS date_submitted
       ,COALESCE(f1.responder_email, f2.responder_email, f3.responder_email, email1) AS responder_email   
       ,COALESCE(f1.subject_name, f2.subject_name, f3.subject_name) AS subject_name
-      ,COALESCE(s.academic_year,f1.academic_year, f2.academic_year, f3.academic_year) AS academic_year
-      ,COALESCE(s.reporting_term,f1.reporting_term, f2.reporting_term, f3.reporting_term) AS reporting_term
+      ,COALESCE(s.academic_year, f1.academic_year, f2.academic_year, f3.academic_year) AS academic_year
+      ,COALESCE(s.reporting_term, f1.reporting_term, f2.reporting_term, f3.reporting_term) AS reporting_term
       ,COALESCE(s.survey_type, f1.survey_type, f2.survey_type, f3.survey_type) AS survey_type
-      ,COALESCE(f1.is_manager,f2.is_manager,f3.is_manager) AS is_manager
+      ,COALESCE(f1.is_manager, f2.is_manager, f3.is_manager) AS is_manager
 FROM teacher_scaffold s
 LEFT JOIN survey_feed f1
   ON s.email1 = f1.responder_email

--- a/surveys/v_surveys.survey_completion.sql
+++ b/surveys/v_surveys.survey_completion.sql
@@ -5,37 +5,42 @@ CREATE OR ALTER VIEW surveys.survey_completion AS
 
 WITH survey_feed AS (
   SELECT _created AS date_created
-        ,CONVERT(DATETIME2,survey_timestamp) AS date_submitted
-        ,subject_name
-        ,LOWER(email) AS responder_email
-        ,gabby.utilities.DATE_TO_SY(_created) AS academic_year
-        ,CASE
-          WHEN MONTH(_created) IN (8, 9, 10) THEN 'SO1'
-          WHEN MONTH(_created) IN (11, 12, 1, 2, 3) THEN 'SO2'
-          WHEN MONTH(_created) IN (4, 5, 6, 7) THEN 'SO3'
-         END AS reporting_term
+        ,CONVERT(DATETIME2,s.survey_timestamp) AS date_submitted
+        ,s.subject_name
+        ,LOWER(s.email) AS responder_email
+        ,gabby.utilities.DATE_TO_SY(s._created) AS academic_year
+        ,CASE WHEN c.name LIKE '%SO1%' THEN 'SO1'
+								      WHEN c.name LIKE '%SO2%' THEN 'SO2'
+														WHEN c.name LIKE '%SO3%' THEN 'SO3'
+														WHEN c.name LIKE '%SO4%' THEN 'SO4'
+									END AS reporting_term
         ,'Self & Others' AS survey_type
-        ,is_manager
-  FROM gabby.surveys.self_and_others_survey
-  WHERE subject_name IS NOT NULL
-    AND _created IS NOT NULL
+        ,s.is_manager
+  FROM gabby.surveys.self_and_others_survey s
+		LEFT JOIN gabby.surveygizmo.survey_campaign_clean_static c
+		  ON c.survey_id = 4561325
+			AND CONVERT(DATETIME2,s.survey_timestamp) BETWEEN c.link_open_date AND c.link_close_date
+  WHERE s.subject_name IS NOT NULL
+    AND s._created IS NOT NULL
 
   UNION ALL
 
-  SELECT _created AS date_created
-        ,CONVERT(DATETIME2,survey_timestamp) AS date_submitted
-        ,subject_name
-        ,LOWER(responder_name) AS responder_email
-        ,gabby.utilities.DATE_TO_SY(_created) AS academic_year
-        ,CASE
-          WHEN MONTH(_created) IN (8, 9, 10) THEN 'MGR1'
-          WHEN MONTH(_created) IN (11, 12, 1) THEN 'MGR2'
-          WHEN MONTH(_created) IN (2, 3, 4) THEN 'MGR3'
-          WHEN MONTH(_created) IN (5, 6, 7) THEN 'MGR4'
-         END AS reporting_term
+  SELECT m._created AS date_created
+        ,CONVERT(DATETIME2,m.survey_timestamp) AS date_submitted
+        ,m.subject_name
+        ,LOWER(m.responder_name) AS responder_email
+        ,gabby.utilities.DATE_TO_SY(m._created) AS academic_year
+        ,CASE WHEN c.name LIKE '%MGR1%' THEN 'MGR1'
+								      WHEN c.name LIKE '%MGR2%' THEN 'MGR2'
+														WHEN c.name LIKE '%MGR3%' THEN 'MGR3'
+														WHEN c.name LIKE '%MGR4%' THEN 'MGR4'
+									END AS reporting_term
         ,'Manager' AS survey_type
         ,NULL AS is_manager
-  FROM gabby.surveys.manager_survey
+  FROM gabby.surveys.manager_survey m
+		LEFT JOIN gabby.surveygizmo.survey_campaign_clean_static c
+		  ON c.survey_id = 4561288
+			AND CONVERT(DATETIME2,m.survey_timestamp) BETWEEN c.link_open_date AND c.link_close_date
   WHERE subject_name IS NOT NULL
     AND _created IS NOT NULL
     AND subject_name IS NOT NULL


### PR DESCRIPTION
The old method locked the terms into specific months - this uses the dates from the surveygizmo campaign. Using LIKE here, so that we capture the oddball campaigns (eg: 2020 MGR1 R9")