### PR TITLE
Update v_extracts.whetstone_users.sql

### DIFF
--- a/extracts/v_extracts.whetstone_users.sql
+++ b/extracts/v_extracts.whetstone_users.sql
@@ -12,7 +12,7 @@ WITH managers AS (
 
   SELECT s.df_employee_number
   FROM gabby.people.staff_crosswalk_static s
-  WHERE s.primary_job IN ('School Leader', 'Assistant School Leader', 'Assistant School Leader, SPED')
+  WHERE s.primary_job IN ('School Leader', 'Assistant School Leader', 'Assistant School Leader, SPED', 'School Leader in Residence')
  )
 
 ,existing_roles AS (


### PR DESCRIPTION
Adding School Leaders in Residence to the managers list

**Code checks:**
1) Is your branch up to date with `main`? Update from `main` and resolve and merge conflicts before submitting.
2) Are you `JOIN`-ing to a subquery? Refactor as a `CTE`.
3) Do your CTEs significantly transform the data, or could they be refactored into simple `JOIN`s?
4) Will every `SELECT` column be used downstream? Remove superfluous columns.
5) Does every table `JOIN` introduce columns that are used downstream? Remove superfluous `JOIN`s.
6) Double check that your SQL conforms to the style guide.
   * All tables should be referenced in three-parts: `{database}.{schema}.{table}`
   * All columns sould be prefixed with a table alias: `t.column_name`
   * All keywords should be UPPERCASE; all identifiers should be `snake_case`
   * In the event an identifier shares a name with a keyword, surround it with [square brackets].
   * Spaces, not tabs.
    
**What is the purpose of this view?**
> *[extract|feed|clean-up|other] Brief explanation...*
This update will add School Leaders in Residence as Coaches in Whetstone in the event that they are not explicitly managers. In some cases SLIRs aren't managers, but are coaches