### PR TITLE
Update v_surveys.survey_tracking.sql

### DIFF
--- a/surveys/v_surveys.survey_tracking.sql
+++ b/surveys/v_surveys.survey_tracking.sql
@@ -127,7 +127,7 @@ LEFT JOIN clean_responses c
  AND st.reporting_term_code = c.reporting_term
  AND st.survey_id = c.survey_id
 WHERE st.survey_id = 4561325 /* S&O Survey Code */
-  AND c.subject_employee_id != COALESCE(st.employee_number, c.df_employee_number)
+  AND c.subject_employee_id <> COALESCE(st.employee_number, c.df_employee_number)
 
 UNION ALL
 
@@ -177,7 +177,7 @@ LEFT JOIN gabby.surveys.so_assignments_long s
  AND c.df_employee_number = s.survey_taker_id
 WHERE c.survey_id = 4561325 /* S&O Survey Code */
   AND s.assignment IS NULL
-  AND c.subject_employee_id != COALESCE(st.employee_number, c.df_employee_number)
+  AND c.subject_employee_id <> COALESCE(st.employee_number, c.df_employee_number)
 
 UNION ALL
 
@@ -219,7 +219,7 @@ JOIN gabby.surveys.so_assignments s
   ON st.employee_number = s.employee_number
  AND s.survey_taker IN ('Yes', 'Yes - Should take manager survey only')
 WHERE st.survey_id = 4561288 /* MGR Survey Code */
-  AND c.subject_employee_id != COALESCE(st.employee_number, c.df_employee_number)
+  AND c.subject_employee_id <> COALESCE(st.employee_number, c.df_employee_number)
 
 UNION
 
@@ -258,7 +258,7 @@ LEFT JOIN survey_term_staff_scaffold st
  AND c.reporting_term = st.reporting_term_code
  AND c.survey_id = st.survey_id
 WHERE st.survey_id = 4561288 /* MGR Survey Code */
-  AND c.subject_employee_id != COALESCE(st.employee_number, c.df_employee_number)
+  AND c.subject_employee_id <> COALESCE(st.employee_number, c.df_employee_number)
 
 UNION ALL
 

--- a/surveys/v_surveys.survey_tracking.sql
+++ b/surveys/v_surveys.survey_tracking.sql
@@ -127,6 +127,7 @@ LEFT JOIN clean_responses c
  AND st.reporting_term_code = c.reporting_term
  AND st.survey_id = c.survey_id
 WHERE st.survey_id = 4561325 /* S&O Survey Code */
+  AND c.subject_employee_id != COALESCE(st.employee_number, c.df_employee_number)
 
 UNION ALL
 
@@ -176,6 +177,7 @@ LEFT JOIN gabby.surveys.so_assignments_long s
  AND c.df_employee_number = s.survey_taker_id
 WHERE c.survey_id = 4561325 /* S&O Survey Code */
   AND s.assignment IS NULL
+  AND c.subject_employee_id != COALESCE(st.employee_number, c.df_employee_number)
 
 UNION ALL
 
@@ -217,6 +219,7 @@ JOIN gabby.surveys.so_assignments s
   ON st.employee_number = s.employee_number
  AND s.survey_taker IN ('Yes', 'Yes - Should take manager survey only')
 WHERE st.survey_id = 4561288 /* MGR Survey Code */
+  AND c.subject_employee_id != COALESCE(st.employee_number, c.df_employee_number)
 
 UNION
 
@@ -255,6 +258,7 @@ LEFT JOIN survey_term_staff_scaffold st
  AND c.reporting_term = st.reporting_term_code
  AND c.survey_id = st.survey_id
 WHERE st.survey_id = 4561288 /* MGR Survey Code */
+  AND c.subject_employee_id != COALESCE(st.employee_number, c.df_employee_number)
 
 UNION ALL
 


### PR DESCRIPTION
Filtering out self-surveys from the manager and Self & Others survey. I don't want to filter them from all surveys because in some cases, folks may take surveys for themselves (eg: Staff info or self-reflection)

**Code checks:**
1) Is your branch up to date with `main`? Update from `main` and resolve and merge conflicts before submitting.
2) Are you `JOIN`-ing to a subquery? Refactor as a `CTE`.
3) Do your CTEs significantly transform the data, or could they be refactored into simple `JOIN`s?
4) Will every `SELECT` column be used downstream? Remove superfluous columns.
5) Does every table `JOIN` introduce columns that are used downstream? Remove superfluous `JOIN`s.
6) Double check that your SQL conforms to the style guide.
   * All tables should be referenced in three-parts: `{database}.{schema}.{table}`
   * All columns sould be prefixed with a table alias: `t.column_name`
   * All keywords should be UPPERCASE; all identifiers should be `snake_case`
   * In the event an identifier shares a name with a keyword, surround it with [square brackets].
   * Spaces, not tabs.
    
**What is the purpose of this view?**
> *[extract|feed|clean-up|other] Brief explanation...*

Removing self-surveys from Manager and Self & Others surveys. Leaving open the possibility that future surveys may have folks giving feedback to themselves (eg: Self-reflection)
