### PR TITLE
Update v_surveygizmo.survey_response_identifiers.sql

### DIFF
--- a/surveygizmo/v_surveygizmo.survey_response_identifiers.sql
+++ b/surveygizmo/v_surveygizmo.survey_response_identifiers.sql
@@ -123,10 +123,10 @@ SELECT rc.survey_response_id
       ,rsch.school_level AS respondent_primary_site_school_level
       ,reh.reports_to_employee_number AS respondent_manager_df_employee_number
 
-      ,rmgr.manager_name AS respondent_manager_name
-      ,rmgr.manager_mail AS respondent_manager_mail
-      ,rmgr.manager_userprincipalname AS respondent_manager_userprincipalname
-      ,rmgr.manager_samaccountname AS respondent_manager_samaccountname
+      ,rmgr.preferred_name AS respondent_manager_name
+      ,rmgr.mail AS respondent_manager_mail
+      ,rmgr.userprincipalname AS respondent_manager_userprincipalname
+      ,rmgr.samaccountname AS respondent_manager_samaccountname
 
       ,subj.preferred_name AS subject_preferred_name
       ,subj.adp_associate_id AS subject_adp_associate_id
@@ -142,10 +142,10 @@ SELECT rc.survey_response_id
       ,ssch.school_level AS subject_primary_site_school_level
       ,seh.reports_to_employee_number AS subject_manager_df_employee_number
 
-      ,smgr.manager_name AS subject_manager_name
-      ,smgr.manager_mail AS subject_manager_mail
-      ,smgr.manager_userprincipalname AS subject_manager_userprincipalname
-      ,smgr.manager_samaccountname AS subject_manager_samaccountname
+      ,smgr.preferred_name AS subject_manager_name
+      ,smgr.mail AS subject_manager_mail
+      ,smgr.userprincipalname AS subject_manager_userprincipalname
+      ,smgr.samaccountname AS subject_manager_samaccountname
 
       ,ROW_NUMBER() OVER(
          PARTITION BY rc.survey_id, sc.academic_year, sc.[name], rc.respondent_employee_number, rc.subject_employee_number


### PR DESCRIPTION
rmgr & smgr were pointing to the manager name, but the JOIN is on manager_employee_number, so we were pulling the manager's manager previously

**Code checks:**
1) Is your branch up to date with `main`? Update from `main` and resolve and merge conflicts before submitting.
2) Are you `JOIN`-ing to a subquery? Refactor as a `CTE`.
3) Do your CTEs significantly transform the data, or could they be refactored into simple `JOIN`s?
4) Will every `SELECT` column be used downstream? Remove superfluous columns.
5) Does every table `JOIN` introduce columns that are used downstream? Remove superfluous `JOIN`s.
6) Double check that your SQL conforms to the style guide.
   * All tables should be referenced in three-parts: `{database}.{schema}.{table}`
   * All columns sould be prefixed with a table alias: `t.column_name`
   * All keywords should be UPPERCASE; all identifiers should be `snake_case`
   * In the event an identifier shares a name with a keyword, surround it with [square brackets].
   * Spaces, not tabs.
    
**What is the purpose of this view?**
Fixing an error in manager relationships on the surveys dashbaords

rmgr & smgr were pointing to the manager name, but the JOIN is on manager_employee_number, so we were pulling the manager's manager previously

> *[extract|feed|clean-up|other] Brief explanation...*
