### PR TITLE
adding new adp custom fields

### DIFF
--- a/adp/v_adp.workers_custom_field_group.sql
+++ b/adp/v_adp.workers_custom_field_group.sql
@@ -38,7 +38,7 @@ SELECT w.associate_oid
       ,NULL AS bit_value
       ,CASE WHEN ISNUMERIC(cfg.codeValue) = 1 THEN CONVERT(INT, cfg.codeValue) END AS numeric_value
       ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.codeValue')) AS code_value
-      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.shortName')) AS short_name
+      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.codeValue')) AS short_name
 FROM gabby.adp.workers w
 CROSS APPLY OPENJSON(w.custom_field_group, '$.codeFields') 
   WITH(
@@ -62,7 +62,7 @@ SELECT w.associate_oid
       ,NULL AS bit_value
       ,NULL AS numeric_value
       ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.codeValue')) AS code_value
-      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.shortName')) AS short_name
+      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.codeValue')) AS short_name
 FROM gabby.adp.workers w
 CROSS APPLY OPENJSON(w.custom_field_group, '$.dateFields') 
   WITH(
@@ -97,7 +97,103 @@ CROSS APPLY OPENJSON(w.custom_field_group, '$.indicatorFields')
 WHERE JSON_QUERY(w.custom_field_group, '$.indicatorFields') <> '{}'
   AND cfg.indicatorValue IS NOT NULL
 
-  UNION ALL
+UNION ALL
+
+SELECT w.associate_oid
+      ,CONVERT(NVARCHAR(16), JSON_VALUE(w.worker_id, '$.idValue')) AS worker_id
+      ,'person' AS parent_object
+      ,'stringFields' AS custom_field_group
+
+      ,cfg.itemID AS item_id
+      ,cfg.stringValue AS string_value
+      ,NULL AS date_value
+      ,NULL AS bit_value
+      ,CASE WHEN ISNUMERIC(cfg.stringValue) = 1 THEN CONVERT(INT, cfg.stringValue) END AS numeric_value
+      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.codeValue')) AS code_value
+      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.shortName')) AS short_name
+FROM gabby.adp.workers w
+CROSS APPLY OPENJSON(w.person, '$.customFieldGroup.stringFields') 
+  WITH(
+    itemID NVARCHAR(128)
+   ,nameCode NVARCHAR(MAX) AS JSON
+   ,stringValue NVARCHAR(128)
+ ) cfg
+WHERE JSON_QUERY(w.person, '$.customFieldGroup.stringFields') <> '{}'
+  AND cfg.stringValue IS NOT NULL
+
+UNION ALL
+
+SELECT w.associate_oid
+      ,CONVERT(NVARCHAR(16), JSON_VALUE(w.worker_id, '$.idValue')) AS worker_id
+      ,'person' AS parent_object
+      ,'codeFields' AS custom_field_group
+
+      ,cfg.itemID AS item_id
+      ,cfg.codeValue AS string_value
+      ,NULL AS date_value
+      ,NULL AS bit_value
+      ,CASE WHEN ISNUMERIC(cfg.codeValue) = 1 THEN CONVERT(INT, cfg.codeValue) END AS numeric_value
+      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.codeValue')) AS code_value
+      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.codeValue')) AS short_name
+FROM gabby.adp.workers w
+CROSS APPLY OPENJSON(w.person, '$.customFieldGroup.codeFields')
+  WITH(
+    itemID NVARCHAR(128)
+   ,nameCode NVARCHAR(MAX) AS JSON
+   ,codeValue NVARCHAR(128)
+ ) cfg
+WHERE JSON_QUERY(w.person, '$.customFieldGroup.codeFields') <> '{}'
+  AND cfg.codeValue IS NOT NULL
+
+UNION ALL
+
+SELECT w.associate_oid
+      ,CONVERT(NVARCHAR(16), JSON_VALUE(w.worker_id, '$.idValue')) AS worker_id
+      ,'person' AS parent_object
+      ,'dateFields' AS custom_field_group
+
+      ,cfg.itemID AS item_id
+      ,cfg.dateValue AS string_value
+      ,CONVERT(DATE, cfg.dateValue) AS date_value
+      ,NULL AS bit_value
+      ,NULL AS numeric_value
+      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.codeValue')) AS code_value
+      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.shortName')) AS short_name
+FROM gabby.adp.workers w
+CROSS APPLY OPENJSON(w.person, '$.customFieldGroup.dateFields') 
+  WITH(
+    itemID NVARCHAR(128)
+   ,nameCode NVARCHAR(MAX) AS JSON
+   ,dateValue NVARCHAR(128)
+ ) cfg
+WHERE JSON_QUERY(w.person, '$.customFieldGroup.dateFields') <> '{}'
+  AND cfg.dateValue IS NOT NULL
+
+UNION ALL
+
+SELECT w.associate_oid
+      ,CONVERT(NVARCHAR(16), JSON_VALUE(w.worker_id, '$.idValue')) AS worker_id
+      ,'person' AS parent_object
+      ,'indicatorFields' AS custom_field_group
+
+      ,cfg.itemID AS item_id
+      ,cfg.indicatorValue AS string_value
+      ,NULL AS date_value
+      ,CONVERT(BIT, cfg.indicatorValue) AS bit_value
+      ,NULL AS numeric_value
+      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.codeValue')) AS code_value
+      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.shortName')) AS short_name
+FROM gabby.adp.workers w
+CROSS APPLY OPENJSON(w.person, '$.customFieldGroup.indicatorFields') 
+  WITH(
+    itemID NVARCHAR(128)
+   ,nameCode NVARCHAR(MAX) AS JSON
+   ,indicatorValue NVARCHAR(128)
+ ) cfg
+WHERE JSON_QUERY(w.person, '$.customFieldGroup.indicatorFields') <> '{}'
+  AND cfg.indicatorValue IS NOT NULL
+
+UNION ALL
 
 SELECT sub.associate_oid
       ,sub.worker_id
@@ -118,7 +214,7 @@ FROM
            ,cfg.itemID AS item_id
            ,cfg.codes
            ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.codeValue')) AS code_value
-           ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.shortName')) AS short_name
+           ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.codeValue')) AS short_name
      FROM gabby.adp.workers w
      CROSS APPLY OPENJSON(w.person, '$.customFieldGroup.multiCodeFields') 
        WITH(

--- a/adp/v_adp.workers_custom_field_group.sql
+++ b/adp/v_adp.workers_custom_field_group.sql
@@ -97,103 +97,7 @@ CROSS APPLY OPENJSON(w.custom_field_group, '$.indicatorFields')
 WHERE JSON_QUERY(w.custom_field_group, '$.indicatorFields') <> '{}'
   AND cfg.indicatorValue IS NOT NULL
 
-UNION ALL
-
-SELECT w.associate_oid
-      ,CONVERT(NVARCHAR(16), JSON_VALUE(w.worker_id, '$.idValue')) AS worker_id
-      ,'person' AS parent_object
-      ,'stringFields' AS custom_field_group
-
-      ,cfg.itemID AS item_id
-      ,cfg.stringValue AS string_value
-      ,NULL AS date_value
-      ,NULL AS bit_value
-      ,CASE WHEN ISNUMERIC(cfg.stringValue) = 1 THEN CONVERT(INT, cfg.stringValue) END AS numeric_value
-      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.codeValue')) AS code_value
-      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.shortName')) AS short_name
-FROM gabby.adp.workers w
-CROSS APPLY OPENJSON(w.person, '$.customFieldGroup.stringFields') 
-  WITH(
-    itemID NVARCHAR(128)
-   ,nameCode NVARCHAR(MAX) AS JSON
-   ,stringValue NVARCHAR(128)
- ) cfg
-WHERE JSON_QUERY(w.person, '$.customFieldGroup.stringFields') <> '{}'
-  AND cfg.stringValue IS NOT NULL
-
-UNION ALL
-
-SELECT w.associate_oid
-      ,CONVERT(NVARCHAR(16), JSON_VALUE(w.worker_id, '$.idValue')) AS worker_id
-      ,'person' AS parent_object
-      ,'codeFields' AS custom_field_group
-
-      ,cfg.itemID AS item_id
-      ,cfg.codeValue AS string_value
-      ,NULL AS date_value
-      ,NULL AS bit_value
-      ,CASE WHEN ISNUMERIC(cfg.codeValue) = 1 THEN CONVERT(INT, cfg.codeValue) END AS numeric_value
-      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.codeValue')) AS code_value
-      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.shortName')) AS short_name
-FROM gabby.adp.workers w
-CROSS APPLY OPENJSON(w.person, '$.customFieldGroup.codeFields')
-  WITH(
-    itemID NVARCHAR(128)
-   ,nameCode NVARCHAR(MAX) AS JSON
-   ,codeValue NVARCHAR(128)
- ) cfg
-WHERE JSON_QUERY(w.person, '$.customFieldGroup.codeFields') <> '{}'
-  AND cfg.codeValue IS NOT NULL
-
-UNION ALL
-
-SELECT w.associate_oid
-      ,CONVERT(NVARCHAR(16), JSON_VALUE(w.worker_id, '$.idValue')) AS worker_id
-      ,'person' AS parent_object
-      ,'dateFields' AS custom_field_group
-
-      ,cfg.itemID AS item_id
-      ,cfg.dateValue AS string_value
-      ,CONVERT(DATE, cfg.dateValue) AS date_value
-      ,NULL AS bit_value
-      ,NULL AS numeric_value
-      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.codeValue')) AS code_value
-      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.shortName')) AS short_name
-FROM gabby.adp.workers w
-CROSS APPLY OPENJSON(w.person, '$.customFieldGroup.dateFields') 
-  WITH(
-    itemID NVARCHAR(128)
-   ,nameCode NVARCHAR(MAX) AS JSON
-   ,dateValue NVARCHAR(128)
- ) cfg
-WHERE JSON_QUERY(w.person, '$.customFieldGroup.dateFields') <> '{}'
-  AND cfg.dateValue IS NOT NULL
-
-UNION ALL
-
-SELECT w.associate_oid
-      ,CONVERT(NVARCHAR(16), JSON_VALUE(w.worker_id, '$.idValue')) AS worker_id
-      ,'person' AS parent_object
-      ,'indicatorFields' AS custom_field_group
-
-      ,cfg.itemID AS item_id
-      ,cfg.indicatorValue AS string_value
-      ,NULL AS date_value
-      ,CONVERT(BIT, cfg.indicatorValue) AS bit_value
-      ,NULL AS numeric_value
-      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.codeValue')) AS code_value
-      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.shortName')) AS short_name
-FROM gabby.adp.workers w
-CROSS APPLY OPENJSON(w.person, '$.customFieldGroup.indicatorFields') 
-  WITH(
-    itemID NVARCHAR(128)
-   ,nameCode NVARCHAR(MAX) AS JSON
-   ,indicatorValue NVARCHAR(128)
- ) cfg
-WHERE JSON_QUERY(w.person, '$.customFieldGroup.indicatorFields') <> '{}'
-  AND cfg.indicatorValue IS NOT NULL
-
-UNION ALL
+  UNION ALL
 
 SELECT sub.associate_oid
       ,sub.worker_id
@@ -231,3 +135,26 @@ CROSS APPLY OPENJSON(sub.codes, '$')
    ,shortName NVARCHAR(MAX)
  ) cfg
 WHERE sub.codes <> '[]'
+
+UNION ALL
+
+SELECT w.associate_oid
+      ,CONVERT(NVARCHAR(16), JSON_VALUE(w.worker_id, '$.idValue')) AS worker_id
+      ,'person' AS parent_object
+      ,'numberFields' AS custom_field_group
+      ,cfg.itemID AS item_id
+      ,cfg.numberValue AS string_value
+      ,NULL AS date_value
+      ,NULL AS bit_value
+      ,CASE WHEN ISNUMERIC(cfg.numberValue) = 1 THEN CONVERT(FLOAT, cfg.numberValue) END AS numeric_value
+      ,cfg.numberValue AS code_value
+      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.codeValue')) AS short_name
+
+FROM gabby.adp.workers w
+CROSS APPLY OPENJSON(w.person, '$.customFieldGroup.numberFields') 
+  WITH(
+    itemID NVARCHAR(128)
+   ,nameCode NVARCHAR(MAX) AS JSON
+   ,numberValue NVARCHAR(128)
+ ) cfg
+WHERE cfg.numberValue IS NOT NULL

--- a/adp/v_adp.workers_custom_field_group.sql
+++ b/adp/v_adp.workers_custom_field_group.sql
@@ -147,7 +147,7 @@ SELECT w.associate_oid
       ,NULL AS date_value
       ,NULL AS bit_value
       ,CASE WHEN ISNUMERIC(cfg.numberValue) = 1 THEN CONVERT(FLOAT, cfg.numberValue) END AS numeric_value
-      ,cfg.numberValue AS code_value
+      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.codeValue')) AS code_value
       ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.codeValue')) AS short_name
 
 FROM gabby.adp.workers w

--- a/adp/v_adp.workers_custom_field_group.sql
+++ b/adp/v_adp.workers_custom_field_group.sql
@@ -10,11 +10,14 @@ SELECT w.associate_oid
 
       ,cfg.itemID AS item_id
       ,cfg.stringValue AS string_value
+      ,NULL AS code_value
       ,NULL AS date_value
       ,NULL AS bit_value
       ,CASE WHEN ISNUMERIC(cfg.stringValue) = 1 THEN CONVERT(INT, cfg.stringValue) END AS numeric_value
-      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.codeValue')) AS code_value
-      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.shortName')) AS short_name
+      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.codeValue')) AS name_code_value
+      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.shortName')) AS name_code_short_name
+      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.longName')) AS name_code_long_name
+      ,cfg.stringValue AS item_value
 FROM gabby.adp.workers w
 CROSS APPLY OPENJSON(w.custom_field_group, '$.stringFields') 
   WITH(
@@ -34,11 +37,14 @@ SELECT w.associate_oid
 
       ,cfg.itemID AS item_id
       ,cfg.codeValue AS string_value
+      ,cfg.codeValue AS code_value
       ,NULL AS date_value
       ,NULL AS bit_value
       ,CASE WHEN ISNUMERIC(cfg.codeValue) = 1 THEN CONVERT(INT, cfg.codeValue) END AS numeric_value
-      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.codeValue')) AS code_value
-      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.codeValue')) AS short_name
+      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.codeValue')) AS name_code_value
+      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.shortName')) AS name_code_short_name
+      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.longName')) AS name_code_long_name
+      ,cfg.codeValue AS item_value
 FROM gabby.adp.workers w
 CROSS APPLY OPENJSON(w.custom_field_group, '$.codeFields') 
   WITH(
@@ -58,11 +64,14 @@ SELECT w.associate_oid
 
       ,cfg.itemID AS item_id
       ,cfg.dateValue AS string_value
+      ,NULL AS code_value
       ,CONVERT(DATE, cfg.dateValue) AS date_value
       ,NULL AS bit_value
       ,NULL AS numeric_value
-      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.codeValue')) AS code_value
-      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.codeValue')) AS short_name
+      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.codeValue')) AS name_code_value
+      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.shortName')) AS name_code_short_name
+      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.longName')) AS name_code_long_name
+      ,cfg.dateValue AS item_value
 FROM gabby.adp.workers w
 CROSS APPLY OPENJSON(w.custom_field_group, '$.dateFields') 
   WITH(
@@ -82,11 +91,14 @@ SELECT w.associate_oid
 
       ,cfg.itemID AS item_id
       ,cfg.indicatorValue AS string_value
+      ,NULL AS code_value
       ,NULL AS date_value
       ,CONVERT(BIT, cfg.indicatorValue) AS bit_value
       ,NULL AS numeric_value
-      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.codeValue')) AS code_value
-      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.shortName')) AS short_name
+      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.codeValue')) AS name_code_value
+      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.shortName')) AS name_code_short_name
+      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.longName')) AS name_code_long_name
+      ,cfg.indicatorValue AS item_value
 FROM gabby.adp.workers w
 CROSS APPLY OPENJSON(w.custom_field_group, '$.indicatorFields') 
   WITH(
@@ -106,11 +118,14 @@ SELECT w.associate_oid
 
       ,cfg.itemID AS item_id
       ,cfg.stringValue AS string_value
+      ,NULL AS code_value
       ,NULL AS date_value
       ,NULL AS bit_value
       ,CASE WHEN ISNUMERIC(cfg.stringValue) = 1 THEN CONVERT(INT, cfg.stringValue) END AS numeric_value
-      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.codeValue')) AS code_value
-      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.shortName')) AS short_name
+      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.codeValue')) AS name_code_value
+      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.shortName')) AS name_code_short_name
+      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.longName')) AS name_code_long_name
+      ,cfg.stringValue AS item_value
 FROM gabby.adp.workers w
 CROSS APPLY OPENJSON(w.person, '$.customFieldGroup.stringFields') 
   WITH(
@@ -130,11 +145,14 @@ SELECT w.associate_oid
 
       ,cfg.itemID AS item_id
       ,cfg.codeValue AS string_value
+      ,cfg.codeValue AS code_value
       ,NULL AS date_value
       ,NULL AS bit_value
       ,CASE WHEN ISNUMERIC(cfg.codeValue) = 1 THEN CONVERT(INT, cfg.codeValue) END AS numeric_value
-      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.codeValue')) AS code_value
-      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.codeValue')) AS short_name
+      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.codeValue')) AS name_code_value
+      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.shortName')) AS name_code_short_name
+      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.longName')) AS name_code_long_name
+      ,cfg.codeValue AS item_value
 FROM gabby.adp.workers w
 CROSS APPLY OPENJSON(w.person, '$.customFieldGroup.codeFields')
   WITH(
@@ -154,11 +172,14 @@ SELECT w.associate_oid
 
       ,cfg.itemID AS item_id
       ,cfg.dateValue AS string_value
+      ,NULL AS code_value
       ,CONVERT(DATE, cfg.dateValue) AS date_value
       ,NULL AS bit_value
       ,NULL AS numeric_value
-      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.codeValue')) AS code_value
-      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.shortName')) AS short_name
+      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.codeValue')) AS name_code_value
+      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.shortName')) AS name_code_short_name
+      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.longName')) AS name_code_long_name
+      ,cfg.dateValue AS item_value
 FROM gabby.adp.workers w
 CROSS APPLY OPENJSON(w.person, '$.customFieldGroup.dateFields') 
   WITH(
@@ -178,11 +199,14 @@ SELECT w.associate_oid
 
       ,cfg.itemID AS item_id
       ,cfg.indicatorValue AS string_value
+      ,NULL AS code_value
       ,NULL AS date_value
       ,CONVERT(BIT, cfg.indicatorValue) AS bit_value
       ,NULL AS numeric_value
-      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.codeValue')) AS code_value
-      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.shortName')) AS short_name
+      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.codeValue')) AS name_code_value
+      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.shortName')) AS name_code_short_name
+      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.longName')) AS name_code_long_name
+      ,cfg.indicatorValue AS item_value
 FROM gabby.adp.workers w
 CROSS APPLY OPENJSON(w.person, '$.customFieldGroup.indicatorFields') 
   WITH(
@@ -195,17 +219,47 @@ WHERE JSON_QUERY(w.person, '$.customFieldGroup.indicatorFields') <> '{}'
 
 UNION ALL
 
+SELECT w.associate_oid
+      ,CONVERT(NVARCHAR(16), JSON_VALUE(w.worker_id, '$.idValue')) AS worker_id
+      ,'person' AS parent_object
+      ,'numberFields' AS custom_field_group
+
+      ,cfg.itemID AS item_id
+      ,cfg.numberValue AS string_value
+      ,NULL AS code_value
+      ,NULL AS date_value
+      ,NULL AS bit_value
+      ,CASE WHEN ISNUMERIC(cfg.numberValue) = 1 THEN CONVERT(FLOAT, cfg.numberValue) END AS numeric_value
+      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.codeValue')) AS name_code_value
+      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.shortName')) AS name_code_short_name
+      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.longName')) AS name_code_long_name
+      ,cfg.numberValue AS item_value
+FROM gabby.adp.workers w
+CROSS APPLY OPENJSON(w.person, '$.customFieldGroup.numberFields') 
+  WITH(
+    itemID NVARCHAR(128)
+   ,nameCode NVARCHAR(MAX) AS JSON
+   ,numberValue NVARCHAR(128)
+ ) cfg
+WHERE cfg.numberValue IS NOT NULL
+
+UNION ALL
+
 SELECT sub.associate_oid
       ,sub.worker_id
       ,'person' AS parent_object
       ,'multiCodeFields' AS custom_field_group
+
       ,sub.item_id
       ,cfg.codeValue AS string_value
+      ,cfg.codeValue AS code_value
       ,NULL AS date_value
       ,NULL AS bit_value
       ,CASE WHEN ISNUMERIC(cfg.codeValue) = 1 THEN CONVERT(INT, cfg.codeValue) END AS numeric_value
-      ,sub.code_value
-      ,sub.short_name
+      ,sub.name_code_value
+      ,sub.name_code_short_name
+      ,sub.name_code_long_name
+      ,cfg.codeValue AS item_value
 FROM
     (
      SELECT w.associate_oid
@@ -213,8 +267,9 @@ FROM
 
            ,cfg.itemID AS item_id
            ,cfg.codes
-           ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.codeValue')) AS code_value
-           ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.codeValue')) AS short_name
+           ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.codeValue')) AS name_code_value
+           ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.shortName')) AS name_code_short_name
+           ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.longName')) AS name_code_long_name
      FROM gabby.adp.workers w
      CROSS APPLY OPENJSON(w.person, '$.customFieldGroup.multiCodeFields') 
        WITH(
@@ -231,26 +286,3 @@ CROSS APPLY OPENJSON(sub.codes, '$')
    ,shortName NVARCHAR(MAX)
  ) cfg
 WHERE sub.codes <> '[]'
-
-UNION ALL
-
-SELECT w.associate_oid
-      ,CONVERT(NVARCHAR(16), JSON_VALUE(w.worker_id, '$.idValue')) AS worker_id
-      ,'person' AS parent_object
-      ,'numberFields' AS custom_field_group
-      ,cfg.itemID AS item_id
-      ,cfg.numberValue AS string_value
-      ,NULL AS date_value
-      ,NULL AS bit_value
-      ,CASE WHEN ISNUMERIC(cfg.numberValue) = 1 THEN CONVERT(FLOAT, cfg.numberValue) END AS numeric_value
-      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.codeValue')) AS code_value
-      ,CONVERT(NVARCHAR(128), JSON_VALUE(cfg.nameCode, '$.codeValue')) AS short_name
-
-FROM gabby.adp.workers w
-CROSS APPLY OPENJSON(w.person, '$.customFieldGroup.numberFields') 
-  WITH(
-    itemID NVARCHAR(128)
-   ,nameCode NVARCHAR(MAX) AS JSON
-   ,numberValue NVARCHAR(128)
- ) cfg
-WHERE cfg.numberValue IS NOT NULL

--- a/adp/v_adp.workers_custom_field_group_wide.sql
+++ b/adp/v_adp.workers_custom_field_group_wide.sql
@@ -1,32 +1,63 @@
 USE gabby
 GO
 
-CREATE OR ALTER VIEW adp.workers_custom_field_group_wide AS
+CREATE OR ALTER VIEW adp.workers_custom_field_group_wide AS (
 
-SELECT associate_oid
-      ,worker_id
-      ,[Attended Relay]
-      ,[COVID 19 Vaccine Type]
-      ,[Date of last vaccine]
-      ,[Employee Number]
-      ,[KIPP Alumni Status]
+WITH multi_pivot AS (
+SELECT worker_id
       ,[Life Experience in Communities We Serve]
-      ,[NJ Pension Number]
-      ,[Preferred Gender]
       ,[Preferred Race/Ethnicity]
       ,[Professional Experience in Communities We Serve]
       ,[Teacher Prep Program]
-      ,[WFMgr Accrual Profile]
-      ,[WFMgr Badge Number]
-      ,[WFMgr EE Type]
-      ,[WFMgr Home Hyperfind]
-      ,[WFMgr LOA Return Date]
-      ,[WFMgr Pay Rule]
-      ,[WFMgr Trigger]
+
+FROM (
+  
+  SELECT worker_id
+        ,code_value
+        ,gabby.dbo.GROUP_CONCAT(string_value) AS string_value
+  FROM gabby.adp.workers_custom_field_group
+  WHERE code_value IN ('Preferred Race/Ethnicity', 'Life Experience in Communities We Serve', 'Professional Experience in Communities We Serve', 'Teacher Prep Program')
+  GROUP BY worker_id, code_value
+       ) sub
+  PIVOT(MAX(string_value) FOR code_value IN ([Life Experience in Communities We Serve]
+                                            ,[Preferred Race/Ethnicity]
+                                            ,[Professional Experience in Communities We Serve]
+                                            ,[Teacher Prep Program]
+                                            )
+      ) p
+  )
+  
+
+SELECT p.associate_oid
+      ,p.worker_id
+      ,p.[Attended Relay]
+      ,p.[COVID 19 Vaccine Type]
+      ,p.[Date of last vaccine]
+      ,p.[Employee Number]
+      ,p.[KIPP Alumni Status]
+      ,p.[NJ Pension Number]
+      ,p.[Preferred Gender]
+      ,p.[WFMgr Accrual Profile]
+      ,p.[WFMgr Badge Number]
+      ,p.[WFMgr EE Type]
+      ,p.[WFMgr Home Hyperfind]
+      ,p.[WFMgr LOA Return Date]
+      ,p.[WFMgr LOA]
+      ,p.[WFMgr Pay Rule]
+      ,p.[WFMgr Trigger]
+      ,p.[Years Teaching - In NJ or FL]
+      ,p.[Years of Professional Experience before joining]
+      ,p.[Years Teaching - In any State]
       ,CASE 
-        WHEN [WFMgr LOA] = 'true' THEN 1
-        WHEN [WFMgr LOA] = 'false' THEN 0
+        WHEN p.[WFMgr LOA] = 'true' THEN 1
+        WHEN p.[WFMgr LOA] = 'false' THEN 0
        END AS [WFMgr LOA]
+
+      ,m.[Life Experience in Communities We Serve]
+      ,m.[Preferred Race/Ethnicity]
+      ,m.[Professional Experience in Communities We Serve]
+      ,m.[Teacher Prep Program]
+
 FROM
     (
      SELECT associate_oid
@@ -43,12 +74,8 @@ PIVOT(
        ,[Date of last vaccine]
        ,[Employee Number]
        ,[KIPP Alumni Status]
-       ,[Life Experience in Communities We Serve]
        ,[NJ Pension Number]
        ,[Preferred Gender]
-       ,[Preferred Race/Ethnicity]
-       ,[Professional Experience in Communities We Serve]
-       ,[Teacher Prep Program]
        ,[WFMgr Accrual Profile]
        ,[WFMgr Badge Number]
        ,[WFMgr EE Type]
@@ -57,5 +84,11 @@ PIVOT(
        ,[WFMgr LOA]
        ,[WFMgr Pay Rule]
        ,[WFMgr Trigger]
+       ,[Years Teaching - In NJ or FL]
+       ,[Years of Professional Experience before joining]
+       ,[Years Teaching - In any State]
       )
  ) p
+
+ LEFT JOIN multi_pivot m
+   ON p.worker_id = m.worker_id

--- a/adp/v_adp.workers_custom_field_group_wide.sql
+++ b/adp/v_adp.workers_custom_field_group_wide.sql
@@ -3,6 +3,15 @@ GO
 
 CREATE OR ALTER VIEW adp.workers_custom_field_group_wide AS
 
+WITH grouped_data AS (
+  SELECT associate_oid
+        ,worker_id
+        ,name_code_value
+        ,gabby.dbo.GROUP_CONCAT(item_value) AS item_value
+  FROM gabby.adp.workers_custom_field_group
+  GROUP BY associate_oid, worker_id, name_code_value
+ )
+
 SELECT p.associate_oid
       ,p.worker_id
       ,p.[Attended Relay]
@@ -17,45 +26,23 @@ SELECT p.associate_oid
       ,p.[WFMgr EE Type]
       ,p.[WFMgr Home Hyperfind]
       ,p.[WFMgr LOA Return Date]
-      ,p.[WFMgr LOA]
       ,p.[WFMgr Pay Rule]
       ,p.[WFMgr Trigger]
       ,p.[Years Teaching - In NJ or FL]
       ,p.[Years of Professional Experience before joining]
       ,p.[Years Teaching - In any State]
-      ,CASE 
-        WHEN p.[WFMgr LOA] = 'true' THEN 1
-        WHEN p.[WFMgr LOA] = 'false' THEN 0
-       END AS [WFMgr LOA]
-
       ,p.[Life Experience in Communities We Serve]
       ,p.[Preferred Race/Ethnicity]
       ,p.[Professional Experience in Communities We Serve]
       ,p.[Teacher Prep Program]
-
-FROM
-    (
-     SELECT associate_oid
-           ,worker_id
-           ,code_value
-           ,string_value
-     FROM gabby.adp.workers_custom_field_group
-     WHERE code_value NOT IN ('Preferred Race/Ethnicity', 'Life Experience in Communities We Serve', 'Professional Experience in Communities We Serve', 'Teacher Prep Program')
-
-     UNION ALL
-
-     SELECT associate_oid
-           ,worker_id
-           ,code_value
-           ,gabby.dbo.GROUP_CONCAT(string_value) AS string_value
-     FROM gabby.adp.workers_custom_field_group
-     WHERE code_value IN ('Preferred Race/Ethnicity', 'Life Experience in Communities We Serve', 'Professional Experience in Communities We Serve', 'Teacher Prep Program')
-     GROUP BY associate_oid, worker_id, code_value
-
-    ) sub
+      ,CASE
+        WHEN p.[WFMgr LOA] = 'true' THEN 1
+        WHEN p.[WFMgr LOA] = 'false' THEN 0
+       END AS [WFMgr LOA]
+FROM grouped_data
 PIVOT(
-  MAX(string_value)
-  FOR code_value IN (
+  MAX(item_value)
+  FOR name_code_value IN (
         [Attended Relay]
        ,[COVID 19 Vaccine Type]
        ,[Date of last vaccine]


### PR DESCRIPTION
adding numeric value fields to workers_custom_field_group and workers_custom_field_group_wide

Adjusting multiselect fields in workers_custom_field_group_wide

**Code checks:**
1) Is your branch up to date with `main`? Update from `main` and resolve and merge conflicts before submitting.
2) Are you `JOIN`-ing to a subquery? Refactor as a `CTE`.
3) Do your CTEs significantly transform the data, or could they be refactored into simple `JOIN`s?
4) Will every `SELECT` column be used downstream? Remove superfluous columns.
5) Does every table `JOIN` introduce columns that are used downstream? Remove superfluous `JOIN`s.
6) Double check that your SQL conforms to the style guide.
   * All tables should be referenced in three-parts: `{database}.{schema}.{table}`
   * All columns sould be prefixed with a table alias: `t.column_name`
   * All keywords should be UPPERCASE; all identifiers should be `snake_case`
   * In the event an identifier shares a name with a keyword, surround it with [square brackets].
   * Spaces, not tabs.
    
**What is the purpose of this view?**
> *[extract|feed|clean-up|other] Brief explanation...*


adding numeric value fields to workers_custom_field_group and workers_custom_field_group_wide

Adjusting multiselect fields in workers_custom_field_group_wide