### PR TITLE
Update v_payroll.payroll_audit.sql

### DIFF
--- a/payroll/v_payroll.payroll_audit.sql
+++ b/payroll/v_payroll.payroll_audit.sql
@@ -286,7 +286,7 @@ WITH payroll_rollup AS (
          ,rate, rate_2, rate_3, rate_used
          ,rg_ern, rg_hrs
          ,sdi_tax, ss_tax
-         ,state_tax_1, state_tax_2, sui_tax
+         ,state_tax_1, state_tax_2, sui_tax, take_home_pay
         )
    ) u
  )
@@ -323,6 +323,8 @@ SELECT sub.position_id
       ,sub.job_title_curr
       ,sub.salary_curr
       ,sub.status_curr
+      ,sub.prev_code_value
+      ,sub.prev_payroll_date
       ,sub.code_value - sub.prev_code_value AS code_value_diff
       ,CASE 
         WHEN sub.payroll_date = sub.prev_payroll_date THEN 'New Payroll Code'


### PR DESCRIPTION
It looks like take_home_pay didn't make it into the list of fields for the unpivot. I'd also like to include prev_code_value and prev_payroll_date, per a request from the HR team

**Code checks:**
1) Is your branch up to date with `main`? Update from `main` and resolve and merge conflicts before submitting.
2) Are you `JOIN`-ing to a subquery? Refactor as a `CTE`.
3) Do your CTEs significantly transform the data, or could they be refactored into simple `JOIN`s?
4) Will every `SELECT` column be used downstream? Remove superfluous columns.
5) Does every table `JOIN` introduce columns that are used downstream? Remove superfluous `JOIN`s.
6) Double check that your SQL conforms to the style guide.
   * All tables should be referenced in three-parts: `{database}.{schema}.{table}`
   * All columns sould be prefixed with a table alias: `t.column_name`
   * All keywords should be UPPERCASE; all identifiers should be `snake_case`
   * In the event an identifier shares a name with a keyword, surround it with [square brackets].
   * Spaces, not tabs.
    
**What is the purpose of this view?**
> *[extract|feed|clean-up|other] Brief explanation...*
