### PR TITLE
Update v_surveys.so_assignments_long.sql

### DIFF
--- a/surveys/v_surveys.so_assignments_long.sql
+++ b/surveys/v_surveys.so_assignments_long.sql
@@ -54,5 +54,8 @@ FROM gabby.people.staff_crosswalk_static c
 JOIN gabby.surveys.so_assignments s
   ON c.df_employee_number = s.employee_number
  AND s.survey_taker = 'Yes'
+JOIN gabby.surveys.so_assignments m
+  ON c.manager_df_employee_number = m.employee_number
+ AND m.survey_taker = 'Yes'
 WHERE c.[status] <> 'TERMINATED'
   AND COALESCE(c.rehire_date, c.original_hire_date) < DATEADD(DAY, -30, GETDATE())


### PR DESCRIPTION
Adjusting the assignment logic so that both the manager and the direct report have to be "opted in" to the S&O survey. Before, a manager was assigned S&O surveys when their direct report was giving S&O survey feedback to others. Now a manager is assigned to give a direct report feedback when the manager is opted into the survey AND the direct report is giving others feedback

**Code checks:**
1) Is your branch up to date with `main`? Update from `main` and resolve and merge conflicts before submitting.
2) Are you `JOIN`-ing to a subquery? Refactor as a `CTE`.
3) Do your CTEs significantly transform the data, or could they be refactored into simple `JOIN`s?
4) Will every `SELECT` column be used downstream? Remove superfluous columns.
5) Does every table `JOIN` introduce columns that are used downstream? Remove superfluous `JOIN`s.
6) Double check that your SQL conforms to the style guide.
   * All tables should be referenced in three-parts: `{database}.{schema}.{table}`
   * All columns sould be prefixed with a table alias: `t.column_name`
   * All keywords should be UPPERCASE; all identifiers should be `snake_case`
   * In the event an identifier shares a name with a keyword, surround it with [square brackets].
   * Spaces, not tabs.
    
**What is the purpose of this view?**
> *[extract|feed|clean-up|other] Brief explanation...*
