### PR TITLE
reverting to regular joins

### DIFF
--- a/surveygizmo/v_surveygizmo.survey_detail.sql
+++ b/surveygizmo/v_surveygizmo.survey_detail.sql
@@ -63,19 +63,19 @@ SELECT s.survey_id
 
       ,COALESCE(qo.option_title_english, srd.answer) AS answer
 FROM gabby.surveygizmo.survey_clean s
-INNER JOIN gabby.surveygizmo.survey_question_clean_static sq
+JOIN gabby.surveygizmo.survey_question_clean_static sq
   ON s.survey_id = sq.survey_id
  AND sq.base_type = 'Question'
  AND sq.is_identifier_question = 0
  AND sq.[type] IN ('RADIO', 'ESSAY', 'TEXTBOX')
-INNER JOIN gabby.surveygizmo.survey_response_data srd
+JOIN gabby.surveygizmo.survey_response_data srd
   ON sq.survey_id = srd.survey_id
  AND sq.survey_question_id = srd.question_id
-LEFT JOIN gabby.surveygizmo.survey_question_options_static qo
+JOIN gabby.surveygizmo.survey_question_options_static qo
   ON srd.survey_id = qo.survey_id
  AND srd.question_id = qo.question_id
  AND srd.answer_id = qo.option_id
-LEFT JOIN gabby.surveygizmo.survey_response_identifiers_static sri
+JOIN gabby.surveygizmo.survey_response_identifiers_static sri
   ON srd.survey_id = sri.survey_id
  AND srd.survey_response_id = sri.survey_response_id
  AND sri.[status] = 'Complete'


### PR DESCRIPTION
**Code checks:**
1) Is your branch up to date with `main`? Update from `main` and resolve and merge conflicts before submitting.
2) Are you `JOIN`-ing to a subquery? Refactor as a `CTE`.
3) Do your CTEs significantly transform the data, or could they be refactored into simple `JOIN`s?
4) Will every `SELECT` column be used downstream? Remove superfluous columns.
5) Does every table `JOIN` introduce columns that are used downstream? Remove superfluous `JOIN`s.
6) Double check that your SQL conforms to the style guide.
   * All tables should be referenced in three-parts: `{database}.{schema}.{table}`
   * All columns sould be prefixed with a table alias: `t.column_name`
   * All keywords should be UPPERCASE; all identifiers should be `snake_case`
   * In the event an identifier shares a name with a keyword, surround it with [square brackets].
   * Spaces, not tabs.
    
**What is the purpose of this view?**
> *[extract|feed|clean-up|other] Brief explanation...*
