### PR TITLE
Adding Work Assignment Start Date

### DIFF
--- a/extracts/v_extracts.gsheets_staff_roster.sql
+++ b/extracts/v_extracts.gsheets_staff_roster.sql
@@ -19,7 +19,7 @@ SELECT df.adp_associate_id AS associate_id
       ,CONVERT(VARCHAR, df.termination_date) AS termination_date
       ,df.mail AS email_addr 
       ,CONVERT(VARCHAR, df.original_hire_date) AS hire_date
-      ,CONVERT(VARCHAR, df.work_assignment_effective_start) AS position_start_date
+      ,CONVERT(VARCHAR, df.work_assignment_start_date) AS position_start_date
       ,df.df_employee_number
       ,df.manager_df_employee_number
       ,df.legal_entity_name

--- a/extracts/v_extracts.gsheets_staff_roster.sql
+++ b/extracts/v_extracts.gsheets_staff_roster.sql
@@ -19,7 +19,7 @@ SELECT df.adp_associate_id AS associate_id
       ,CONVERT(VARCHAR, df.termination_date) AS termination_date
       ,df.mail AS email_addr 
       ,CONVERT(VARCHAR, df.original_hire_date) AS hire_date
-      ,CONVERT(VARCHAR, df.position_effective_from_date) AS position_start_date
+      ,CONVERT(VARCHAR, df.work_assignment_effective_start) AS position_start_date
       ,df.df_employee_number
       ,df.manager_df_employee_number
       ,df.legal_entity_name

--- a/people/v_people.staff_crosswalk.sql
+++ b/people/v_people.staff_crosswalk.sql
@@ -144,6 +144,8 @@ FROM
            ,adm.samaccountname AS manager_samaccountname
            ,adm.userprincipalname AS manager_userprincipalname
            ,adm.mail AS manager_mail
+
+           ,sr.work_assignment_start_date
      FROM gabby.people.staff_roster sr
      LEFT JOIN gabby.people.id_crosswalk_powerschool idps
        ON sr.employee_number = idps.df_employee_number

--- a/people/v_people.staff_crosswalk.sql
+++ b/people/v_people.staff_crosswalk.sql
@@ -36,6 +36,7 @@ SELECT sub.employee_number AS df_employee_number
       ,sub.job_family
       ,sub.position_effective_start_date AS position_effective_from_date
       ,sub.position_effective_end_date AS position_effective_to_date
+      ,sub.work_assignment_start_date
       ,sub.manager_employee_number AS manager_df_employee_number
       ,sub.worker_category AS payclass
       ,sub.wfmgr_pay_rule AS paytype
@@ -102,6 +103,7 @@ FROM
            ,sr.job_family
            ,sr.position_effective_start_date
            ,sr.position_effective_end_date
+           ,sr.work_assignment_start_date
            ,sr.manager_employee_number
            ,sr.worker_category
            ,sr.wfmgr_pay_rule
@@ -144,8 +146,6 @@ FROM
            ,adm.samaccountname AS manager_samaccountname
            ,adm.userprincipalname AS manager_userprincipalname
            ,adm.mail AS manager_mail
-
-           ,sr.work_assignment_start_date
      FROM gabby.people.staff_roster sr
      LEFT JOIN gabby.people.id_crosswalk_powerschool idps
        ON sr.employee_number = idps.df_employee_number

--- a/people/v_people.staff_roster.sql
+++ b/people/v_people.staff_roster.sql
@@ -27,6 +27,7 @@ WITH all_staff AS (
         ,eh.effective_start_date
         ,eh.status_effective_start_date
         ,eh.primary_position
+        ,eh.work_assignment_start_date
   FROM gabby.people.employment_history_static eh
   WHERE CONVERT(DATE, GETDATE()) BETWEEN eh.effective_start_date AND eh.effective_end_date
 
@@ -52,6 +53,7 @@ WITH all_staff AS (
         ,ps.effective_start_date
         ,ps.status_effective_start_date
         ,ps.primary_position
+        ,ps.work_assignment_start_date
   FROM gabby.people.employment_history_static ps
   WHERE ps.status_effective_start_date > CONVERT(DATE, GETDATE())
     AND ps.position_status = 'Active'
@@ -147,6 +149,7 @@ WITH all_staff AS (
         ,sub.primary_position
         ,sub.position_effective_start_date
         ,sub.position_effective_end_date
+        ,sub.work_assignment_start_date
         ,sub.original_hire_date
         ,sub.rehire_date
         ,sub.termination_date
@@ -232,7 +235,7 @@ WITH all_staff AS (
                           ,eh.status_effective_start_date DESC
                           ,CASE WHEN eh.position_status = 'Terminated' THEN 0 ELSE 1 END DESC
                           ,eh.effective_start_date DESC) AS rn
-
+             ,eh.work_assignment_start_date
              ,ea.first_name
              ,ea.last_name
              ,ea.primary_address_city AS address_city
@@ -423,6 +426,8 @@ SELECT c.employee_number
       ,gl.student_grade_level AS primary_grade_taught
 
       ,ads.userprincipalname
+
+      ,COALESCE(c.work_assignment_start_date,c.position_effective_start_date) AS work_assignment_start_date
 FROM clean_staff c
 LEFT JOIN gabby.people.school_crosswalk s
   ON c.[location] = s.site_name

--- a/people/v_people.staff_roster.sql
+++ b/people/v_people.staff_roster.sql
@@ -27,7 +27,7 @@ WITH all_staff AS (
         ,eh.effective_start_date
         ,eh.status_effective_start_date
         ,eh.primary_position
-        ,eh.work_assignment_start_date
+        ,COALESCE(eh.work_assignment_start_date, eh.position_effective_start_date) AS work_assignment_start_date
   FROM gabby.people.employment_history_static eh
   WHERE CONVERT(DATE, GETDATE()) BETWEEN eh.effective_start_date AND eh.effective_end_date
 
@@ -53,7 +53,7 @@ WITH all_staff AS (
         ,ps.effective_start_date
         ,ps.status_effective_start_date
         ,ps.primary_position
-        ,ps.work_assignment_start_date
+        ,COALESCE(ps.work_assignment_start_date, ps.position_effective_start_date) AS work_assignment_start_date
   FROM gabby.people.employment_history_static ps
   WHERE ps.status_effective_start_date > CONVERT(DATE, GETDATE())
     AND ps.position_status = 'Active'
@@ -216,6 +216,7 @@ WITH all_staff AS (
              ,eh.[location]
              ,eh.position_effective_start_date
              ,eh.position_effective_end_date
+             ,eh.work_assignment_start_date
              ,eh.annual_salary
              ,eh.primary_position
              ,CONVERT(NVARCHAR(256), NULL) AS job_family -- on the way
@@ -235,7 +236,6 @@ WITH all_staff AS (
                           ,eh.status_effective_start_date DESC
                           ,CASE WHEN eh.position_status = 'Terminated' THEN 0 ELSE 1 END DESC
                           ,eh.effective_start_date DESC) AS rn
-             ,eh.work_assignment_start_date
              ,ea.first_name
              ,ea.last_name
              ,ea.primary_address_city AS address_city
@@ -336,6 +336,7 @@ SELECT c.employee_number
       ,c.primary_position
       ,c.position_effective_start_date
       ,c.position_effective_end_date
+      ,c.work_assignment_start_date
       ,c.original_hire_date
       ,c.rehire_date
       ,c.termination_date
@@ -426,8 +427,6 @@ SELECT c.employee_number
       ,gl.student_grade_level AS primary_grade_taught
 
       ,ads.userprincipalname
-
-      ,COALESCE(c.work_assignment_start_date,c.position_effective_start_date) AS work_assignment_start_date
 FROM clean_staff c
 LEFT JOIN gabby.people.school_crosswalk s
   ON c.[location] = s.site_name


### PR DESCRIPTION
Adding Work Assignment Start Date to staff roster, staff crosswalk, and replacing position start date with work assignment start date on gsheets_staff_roster

Staff roster feeds staff crosswalk, and staff crosswalk feeds gsheets staff roster, so the order of the updates should be:

1) Staff Roster
2) Staff Crosswalk
3) Gsheets Staff Roster

**Code checks:**
1) Is your branch up to date with `main`? Update from `main` and resolve and merge conflicts before submitting.
2) Are you `JOIN`-ing to a subquery? Refactor as a `CTE`.
3) Do your CTEs significantly transform the data, or could they be refactored into simple `JOIN`s?
4) Will every `SELECT` column be used downstream? Remove superfluous columns.
5) Does every table `JOIN` introduce columns that are used downstream? Remove superfluous `JOIN`s.
6) Double check that your SQL conforms to the style guide.
   * All tables should be referenced in three-parts: `{database}.{schema}.{table}`
   * All columns sould be prefixed with a table alias: `t.column_name`
   * All keywords should be UPPERCASE; all identifiers should be `snake_case`
   * In the event an identifier shares a name with a keyword, surround it with [square brackets].
   * Spaces, not tabs.
    
**What is the purpose of this view?**
> *[extract|feed|clean-up|other] Brief explanation...*
