### PR TITLE
adding survey_id field

### DIFF
--- a/extracts/v_extracts.gsheets_survey_completion.sql
+++ b/extracts/v_extracts.gsheets_survey_completion.sql
@@ -10,11 +10,14 @@ WITH incomplete_surveys AS (
         ,survey_round_open
         ,survey_round_close
         ,survey_completion_date 
+        ,survey_id
         ,ROW_NUMBER() OVER(
            PARTITION BY survey_taker_id
-             ORDER BY reporting_term DESC) AS rn_null
+             ORDER BY reporting_term) AS rn_null
   FROM gabby.surveys.survey_tracking t
   WHERE survey_completion_date IS NULL
+  /*Limiting to non-Staff Update surveys*/
+    AND survey_id <> '6330385'
     AND CONVERT(DATE, GETDATE()) BETWEEN survey_round_open AND survey_round_close
  )
 
@@ -24,6 +27,7 @@ SELECT i.academic_year
       ,i.survey_round_open
       ,i.survey_round_close
       ,i.survey_completion_date 
+      ,i.survey_id
 
       ,c.preferred_first_name
       ,c.preferred_last_name

--- a/surveys/v_surveys.survey_tracking.sql
+++ b/surveys/v_surveys.survey_tracking.sql
@@ -129,6 +129,7 @@ SELECT COALESCE(st.respondent_employee_number, c.respondent_employee_number) AS 
       ,st.survey_round_open
       ,st.survey_round_close
       ,st.survey_default_link
+      ,st.survey_id
 
       ,sa.survey_round_status
       ,COALESCE(sa.assignment, c.subject_name) AS assignment
@@ -191,6 +192,7 @@ SELECT COALESCE(st.respondent_employee_number, c.respondent_employee_number) AS 
       ,st.survey_round_open
       ,st.survey_round_close
       ,st.survey_default_link
+      ,st.survey_id
 
       ,'Yes' AS survey_round_status
       ,c.subject_name AS assignment
@@ -254,6 +256,7 @@ SELECT COALESCE(st.respondent_employee_number, c.respondent_employee_number) AS 
       ,st.survey_round_open
       ,st.survey_round_close
       ,st.survey_default_link
+      ,st.survey_id
 
       ,sa.survey_taker AS survey_round_status
       ,'Your Manager' AS assignment
@@ -310,6 +313,7 @@ SELECT COALESCE(st.respondent_employee_number, c.respondent_employee_number) AS 
       ,st.survey_round_open
       ,st.survey_round_close
       ,st.survey_default_link
+      ,st.survey_id
 
       ,'Yes' AS survey_round_status
       ,'Your Manager' AS assignment
@@ -363,6 +367,7 @@ SELECT st.respondent_employee_number AS survey_taker_id
       ,st.survey_round_open
       ,st.survey_round_close
       ,st.survey_default_link
+      ,st.survey_id
 
       ,'Yes' AS survey_round_status
       ,sa.engagement_survey_assignment AS assignment
@@ -417,6 +422,7 @@ SELECT st.respondent_employee_number AS survey_taker_id
       ,st.survey_round_open
       ,st.survey_round_close
       ,st.survey_default_link
+      ,st.survey_id
 
       ,'Yes' AS survey_round_status
       ,'Update Your Staff Info' AS assignment
@@ -468,6 +474,7 @@ SELECT st.respondent_employee_number AS survey_taker_id
       ,st.survey_round_open
       ,st.survey_round_close
       ,st.survey_default_link
+      ,st.survey_id
 
       ,'Yes' AS survey_round_status
       ,'One Off Staff Survey' AS assignment
@@ -519,6 +526,7 @@ SELECT st.respondent_employee_number AS survey_taker_id
       ,st.survey_round_open
       ,st.survey_round_close
       ,st.survey_default_link
+      ,st.survey_id
 
       ,'Yes' AS survey_round_status
       ,'Intent to Return' AS assignment


### PR DESCRIPTION
Need to filter out Staff Updates from the survey completion view to limit reminders to incompletes for other surveys.

Adding survey_id to survey_tracking and filter on survey_id to gsheets_survey_completion.

**Code checks:**
1) Is your branch up to date with `main`? Update from `main` and resolve and merge conflicts before submitting.
2) Are you `JOIN`-ing to a subquery? Refactor as a `CTE`.
3) Do your CTEs significantly transform the data, or could they be refactored into simple `JOIN`s?
4) Will every `SELECT` column be used downstream? Remove superfluous columns.
5) Does every table `JOIN` introduce columns that are used downstream? Remove superfluous `JOIN`s.
6) Double check that your SQL conforms to the style guide.
   * All tables should be referenced in three-parts: `{database}.{schema}.{table}`
   * All columns sould be prefixed with a table alias: `t.column_name`
   * All keywords should be UPPERCASE; all identifiers should be `snake_case`
   * In the event an identifier shares a name with a keyword, surround it with [square brackets].
   * Spaces, not tabs.
    
**What is the purpose of this view?**
> *[extract|feed|clean-up|other] Brief explanation...*
