### PR TITLE
removing paras

### DIFF
--- a/extracts/v_extracts.whetstone_users.sql
+++ b/extracts/v_extracts.whetstone_users.sql
@@ -180,3 +180,4 @@ LEFT JOIN existing_roles er
 LEFT JOIN obsv_grp og
   ON u.[user_id] = og.[user_id]
  AND sch._id = og.school_id
+ WHERE sub.role_name <> 'No Role'

--- a/extracts/v_extracts.whetstone_users.sql
+++ b/extracts/v_extracts.whetstone_users.sql
@@ -1,7 +1,7 @@
 USE gabby
 GO
 
---CREATE OR ALTER VIEW extracts.whetstone_users AS
+CREATE OR ALTER VIEW extracts.whetstone_users AS
 
 WITH managers AS (
   SELECT DISTINCT
@@ -128,9 +128,7 @@ FROM
            ,scw.primary_on_site_department AS course_name
            ,scw.preferred_first_name + ' ' + scw.preferred_last_name AS [user_name]
            ,CASE WHEN scw.primary_site_schoolid <> 0 THEN scw.primary_site END AS school_name
-           ,CAST(CASE WHEN scw.[status] = 'TERMINATED' THEN 1 
-                      WHEN scw.primary_job = 'Paraprofessional' THEN 1
-                      ELSE 0 END AS BIT) AS inactive
+           ,CAST(CASE WHEN scw.[status] = 'TERMINATED' THEN 1 ELSE 0 END AS BIT) AS inactive
            ,CASE WHEN scw.grades_taught = 0 THEN 'K' ELSE CAST(scw.grades_taught AS VARCHAR) END AS grade_abbreviation
            ,CASE
              /* network admins */

--- a/extracts/v_extracts.whetstone_users.sql
+++ b/extracts/v_extracts.whetstone_users.sql
@@ -153,7 +153,6 @@ FROM
              /* basic roles */
              WHEN scw.is_manager = 1 THEN 'Coach'
              WHEN scw.primary_job IN ('Teacher', 'Teacher ESL', 'Co-Teacher', 'Learning Specialist', 'Learning Specialist Coordinator','Teacher in Residence', 'Teaching Fellow') THEN 'Teacher'
-             WHEN scw.primary_job = 'Paraprofessional' AND scw.primary_site = 'KIPP Life Academy' THEN 'Teacher'
              ELSE 'No Role'
             END AS role_name
      FROM gabby.people.staff_crosswalk_static scw

--- a/extracts/v_extracts.whetstone_users.sql
+++ b/extracts/v_extracts.whetstone_users.sql
@@ -129,11 +129,7 @@ FROM
            ,scw.preferred_first_name + ' ' + scw.preferred_last_name AS [user_name]
            ,CASE WHEN scw.primary_site_schoolid <> 0 THEN scw.primary_site END AS school_name
            ,CAST(CASE WHEN scw.[status] = 'TERMINATED' THEN 1 
-                      WHEN scw.primary_job NOT IN ('Achievement Director', 'Chief Academic Officer', 'Chief Of Staff', 'Director', 'Head of Schools'
-                                     ,'Director High School Literacy Curriculum', 'Director Literacy Achievement', 'Director Math Achievement'
-                                     ,'Director Middle School Literacy Curriculum','Head of Schools in Residence','Managing Director', 'Director'
-                                     ,'Achievement Director', 'Teacher', 'Teacher ESL', 'Co-Teacher', 'Learning Specialist','Analyst','Senior Analyst'
-                                     ,'Learning Specialist Coordinator','Teacher in Residence', 'Teaching Fellow') THEN 1
+                      WHEN scw.primary_job = 'Paraprofessional' THEN 1
                       ELSE 0 END AS BIT) AS inactive
            ,CASE WHEN scw.grades_taught = 0 THEN 'K' ELSE CAST(scw.grades_taught AS VARCHAR) END AS grade_abbreviation
            ,CASE

--- a/extracts/v_extracts.whetstone_users.sql
+++ b/extracts/v_extracts.whetstone_users.sql
@@ -181,4 +181,4 @@ LEFT JOIN existing_roles er
 LEFT JOIN obsv_grp og
   ON u.[user_id] = og.[user_id]
  AND sch._id = og.school_id
- WHERE sub.role_name <> 'No Role'
+WHERE sub.role_name <> 'No Role'

--- a/extracts/v_extracts.whetstone_users.sql
+++ b/extracts/v_extracts.whetstone_users.sql
@@ -136,8 +136,9 @@ FROM
              WHEN scw.primary_on_site_department IN ('Teaching and Learning', 'School Support', 'New Teacher Development') 
               AND scw.primary_job IN ('Achievement Director', 'Chief Academic Officer', 'Chief Of Staff', 'Director', 'Head of Schools'
                                      ,'Director High School Literacy Curriculum', 'Director Literacy Achievement', 'Director Math Achievement'
-                                     ,'Director Middle School Literacy Curriculum','Head of Schools in Residence','Assistant Dean', 'Assistant School Leader', 'Assistant School Leader, SPED', 'Dean'
-                                     ,'Dean of Students', 'Director of New Teacher Development','School Leader in Residence','School Leader') 
+                                     ,'Director Middle School Literacy Curriculum', 'Head of Schools in Residence', 'Assistant Dean'
+                                     ,'Assistant School Leader', 'Assistant School Leader, SPED', 'Dean', 'Dean of Students'
+                                     ,'Director of New Teacher Development','School Leader in Residence','School Leader')
                   THEN 'Sub Admin'
              WHEN scw.primary_on_site_department = 'Special Education' 
               AND scw.primary_job IN ('Managing Director', 'Director', 'Achievement Director') 

--- a/extracts/v_extracts.whetstone_users.sql
+++ b/extracts/v_extracts.whetstone_users.sql
@@ -1,7 +1,7 @@
 USE gabby
 GO
 
-CREATE OR ALTER VIEW extracts.whetstone_users AS
+--CREATE OR ALTER VIEW extracts.whetstone_users AS
 
 WITH managers AS (
   SELECT DISTINCT
@@ -128,7 +128,13 @@ FROM
            ,scw.primary_on_site_department AS course_name
            ,scw.preferred_first_name + ' ' + scw.preferred_last_name AS [user_name]
            ,CASE WHEN scw.primary_site_schoolid <> 0 THEN scw.primary_site END AS school_name
-           ,CAST(CASE WHEN scw.[status] = 'TERMINATED' THEN 1 ELSE 0 END AS BIT) AS inactive
+           ,CAST(CASE WHEN scw.[status] = 'TERMINATED' THEN 1 
+                      WHEN scw.primary_job NOT IN ('Achievement Director', 'Chief Academic Officer', 'Chief Of Staff', 'Director', 'Head of Schools'
+                                     ,'Director High School Literacy Curriculum', 'Director Literacy Achievement', 'Director Math Achievement'
+                                     ,'Director Middle School Literacy Curriculum','Head of Schools in Residence','Managing Director', 'Director'
+                                     ,'Achievement Director', 'Teacher', 'Teacher ESL', 'Co-Teacher', 'Learning Specialist','Analyst','Senior Analyst'
+                                     ,'Learning Specialist Coordinator','Teacher in Residence', 'Teaching Fellow') THEN 1
+                      ELSE 0 END AS BIT) AS inactive
            ,CASE WHEN scw.grades_taught = 0 THEN 'K' ELSE CAST(scw.grades_taught AS VARCHAR) END AS grade_abbreviation
            ,CASE
              /* network admins */
@@ -136,7 +142,8 @@ FROM
              WHEN scw.primary_on_site_department IN ('Teaching and Learning', 'School Support', 'New Teacher Development') 
               AND scw.primary_job IN ('Achievement Director', 'Chief Academic Officer', 'Chief Of Staff', 'Director', 'Head of Schools'
                                      ,'Director High School Literacy Curriculum', 'Director Literacy Achievement', 'Director Math Achievement'
-                                     ,'Director Middle School Literacy Curriculum') 
+                                     ,'Director Middle School Literacy Curriculum','Head of Schools in Residence','Assistant Dean', 'Assistant School Leader', 'Assistant School Leader, SPED', 'Dean'
+                                     ,'Dean of Students', 'Director of New Teacher Development','School Leader in Residence','School Leader') 
                   THEN 'Sub Admin'
              WHEN scw.primary_on_site_department = 'Special Education' 
               AND scw.primary_job IN ('Managing Director', 'Director', 'Achievement Director') 
@@ -151,7 +158,8 @@ FROM
                   THEN 'School Assistant Admin' 
              /* basic roles */
              WHEN scw.is_manager = 1 THEN 'Coach'
-             WHEN scw.primary_job IN ('Teacher', 'Teacher ESL', 'Co-Teacher', 'Learning Specialist', 'Learning Specialist Coordinator','Teacher in Residence', 'Teaching Fellow', 'Paraprofessional') THEN 'Teacher'
+             WHEN scw.primary_job IN ('Teacher', 'Teacher ESL', 'Co-Teacher', 'Learning Specialist', 'Learning Specialist Coordinator','Teacher in Residence', 'Teaching Fellow') THEN 'Teacher'
+             WHEN scw.primary_job = 'Paraprofessional' AND scw.primary_site = 'KIPP Life Academy' THEN 'Teacher'
              ELSE 'No Role'
             END AS role_name
      FROM gabby.people.staff_crosswalk_static scw
@@ -179,4 +187,3 @@ LEFT JOIN existing_roles er
 LEFT JOIN obsv_grp og
   ON u.[user_id] = og.[user_id]
  AND sch._id = og.school_id
-WHERE sub.role_name <> 'No Role'


### PR DESCRIPTION
Intent is to remove paraprofessional users from getting/having Whetstone roles, and inactivate users without the included roles.

**Code checks:**
1) Is your branch up to date with `main`? Update from `main` and resolve and merge conflicts before submitting.
2) Are you `JOIN`-ing to a subquery? Refactor as a `CTE`.
3) Do your CTEs significantly transform the data, or could they be refactored into simple `JOIN`s?
4) Will every `SELECT` column be used downstream? Remove superfluous columns.
5) Does every table `JOIN` introduce columns that are used downstream? Remove superfluous `JOIN`s.
6) Double check that your SQL conforms to the style guide.
   * All tables should be referenced in three-parts: `{database}.{schema}.{table}`
   * All columns sould be prefixed with a table alias: `t.column_name`
   * All keywords should be UPPERCASE; all identifiers should be `snake_case`
   * In the event an identifier shares a name with a keyword, surround it with [square brackets].
   * Spaces, not tabs.
    
**What is the purpose of this view?**
> *[extract|feed|clean-up|other] Brief explanation...*
